### PR TITLE
Constrain outline candidate points by global bounds

### DIFF
--- a/lib/OutlineSegmentCandidatePointSolver/OutlineSegmentCandidatePointSolver.ts
+++ b/lib/OutlineSegmentCandidatePointSolver/OutlineSegmentCandidatePointSolver.ts
@@ -56,6 +56,7 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
     packedComponents: PackedComponent[]
     componentToPack: InputComponent
     obstacles?: InputObstacle[]
+    bounds?: Bounds
     globalBounds?: Bounds
   }) {
     super()
@@ -67,7 +68,7 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
     this.packedComponents = params.packedComponents
     this.componentToPack = params.componentToPack
     this.obstacles = params.obstacles ?? []
-    this.globalBounds = params.globalBounds
+    this.globalBounds = params.globalBounds ?? params.bounds
   }
 
   override getConstructorParams(): ConstructorParameters<
@@ -83,6 +84,7 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
       componentToPack: this.componentToPack,
       obstacles: this.obstacles,
       globalBounds: this.globalBounds,
+      bounds: this.globalBounds,
     }
   }
 
@@ -169,12 +171,22 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
         Math.sign(this.outlineSegment[1].y - this.outlineSegment[0].y),
       ),
     }
-    const viableBounds = {
+    let viableBounds = {
       minX: largestRectBounds.minX - componentBounds.minX * segmentNormAbs.x,
       minY: largestRectBounds.minY - componentBounds.minY * segmentNormAbs.y,
       maxX: largestRectBounds.maxX - componentBounds.maxX * segmentNormAbs.x,
       maxY: largestRectBounds.maxY - componentBounds.maxY * segmentNormAbs.y,
     }
+
+    if (this.globalBounds) {
+      viableBounds = {
+        minX: Math.max(viableBounds.minX, this.globalBounds.minX),
+        minY: Math.max(viableBounds.minY, this.globalBounds.minY),
+        maxX: Math.min(viableBounds.maxX, this.globalBounds.maxX),
+        maxY: Math.min(viableBounds.maxY, this.globalBounds.maxY),
+      }
+    }
+
     this.viableBounds = viableBounds
 
     const viableBoundsWidth = viableBounds.maxX - viableBounds.minX

--- a/tests/outline-segment-global-bounds.test.ts
+++ b/tests/outline-segment-global-bounds.test.ts
@@ -1,0 +1,75 @@
+import { test, expect } from "bun:test"
+import type { Point } from "@tscircuit/math-utils"
+import type { InputComponent } from "../lib/types"
+import { OutlineSegmentCandidatePointSolver } from "../lib/OutlineSegmentCandidatePointSolver/OutlineSegmentCandidatePointSolver"
+
+// Helper to create a basic outline and component
+const outline: [Point, Point][] = [
+  [
+    { x: 0, y: 100 },
+    { x: 400, y: 100 },
+  ],
+  [
+    { x: 400, y: 100 },
+    { x: 400, y: 0 },
+  ],
+  [
+    { x: 400, y: 0 },
+    { x: 0, y: 0 },
+  ],
+  [
+    { x: 0, y: 0 },
+    { x: 0, y: 100 },
+  ],
+]
+
+const component: InputComponent = {
+  componentId: "U1",
+  pads: [
+    {
+      padId: "P1",
+      networkId: "N1",
+      type: "rect",
+      offset: { x: 0, y: 0 },
+      size: { x: 10, y: 10 },
+    },
+  ],
+}
+
+test("OutlineSegmentCandidatePointSolver respects globalBounds", () => {
+  const solver = new OutlineSegmentCandidatePointSolver({
+    outlineSegment: outline[0]!,
+    fullOutline: outline,
+    componentRotationDegrees: 0,
+    packStrategy: "minimum_sum_distance_to_network",
+    minGap: 1,
+    packedComponents: [],
+    componentToPack: component,
+    globalBounds: { minX: 50, minY: 0, maxX: 150, maxY: 200 },
+  })
+
+  solver.solve()
+
+  expect(solver.viableBounds).toBeDefined()
+  expect(solver.viableBounds!.minX).toBeGreaterThanOrEqual(50)
+  expect(solver.viableBounds!.maxX).toBeLessThanOrEqual(150)
+})
+
+test("OutlineSegmentCandidatePointSolver accepts bounds alias", () => {
+  const solver = new OutlineSegmentCandidatePointSolver({
+    outlineSegment: outline[0]!,
+    fullOutline: outline,
+    componentRotationDegrees: 0,
+    packStrategy: "minimum_sum_distance_to_network",
+    minGap: 1,
+    packedComponents: [],
+    componentToPack: component,
+    bounds: { minX: 60, minY: 0, maxX: 160, maxY: 200 },
+  })
+
+  solver.solve()
+
+  expect(solver.viableBounds).toBeDefined()
+  expect(solver.viableBounds!.minX).toBeGreaterThanOrEqual(60)
+  expect(solver.viableBounds!.maxX).toBeLessThanOrEqual(160)
+})

--- a/tests/repros/__snapshots__/repro05.snap.svg
+++ b/tests/repros/__snapshots__/repro05.snap.svg
@@ -1,64 +1,64 @@
 <svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
   <rect width="100%" height="100%" fill="white" />
   <g>
-    <polyline data-points="-0.35,-0.44999999999999984 0.44973,-1.1749999999999998" data-type="line" data-label="" points="191.35135135135135,259.4594594594594 312.39156756756756,369.18918918918916" fill="none" stroke="hsl(0, 100%, 50%)" stroke-width="1" />
+    <polyline data-points="-0.35,-0.44999999999999984 0.44973,-1.1749999999999998" data-type="line" data-label="" points="241.76470588235296,221.17647058823525 373.4849411764706,340.58823529411757" fill="none" stroke="hsl(0, 100%, 50%)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.35,-0.44999999999999984 1.0499999999999998,-1.1999999999999997" data-type="line" data-label="" points="191.35135135135135,259.4594594594594 403.2432432432432,372.9729729729729" fill="none" stroke="hsl(0, 100%, 50%)" stroke-width="1" />
+    <polyline data-points="-0.35,-0.44999999999999984 -0.15000000000000008,-2.65" data-type="line" data-label="" points="241.76470588235296,221.17647058823525 274.70588235294116,583.5294117647059" fill="none" stroke="hsl(0, 100%, 50%)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.44973,-1.1749999999999998 1.0499999999999998,-1.1999999999999997" data-type="line" data-label="" points="312.39156756756756,369.18918918918916 403.2432432432432,372.9729729729729" fill="none" stroke="hsl(0, 100%, 50%)" stroke-width="1" />
+    <polyline data-points="0.44973,-1.1749999999999998 -0.15000000000000008,-2.65" data-type="line" data-label="" points="373.4849411764706,340.58823529411757 274.70588235294116,583.5294117647059" fill="none" stroke="hsl(0, 100%, 50%)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.25,-0.7499999999999999 0.45027,-2.275" data-type="line" data-label="" points="433.51351351351354,304.86486486486484 312.4732972972973,535.6756756756756" fill="none" stroke="hsl(75, 100%, 50%)" stroke-width="1" />
+    <polyline data-points="1.25,-0.7499999999999999 0.45027,-2.275" data-type="line" data-label="" points="505.2941176470589,270.5882352941176 373.5738823529412,521.7647058823529" fill="none" stroke="hsl(75, 100%, 50%)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.25,-0.7499999999999999 2.25,-1.1999999999999997" data-type="line" data-label="" points="433.51351351351354,304.86486486486484 584.8648648648648,372.9729729729729" fill="none" stroke="hsl(75, 100%, 50%)" stroke-width="1" />
+    <polyline data-points="1.25,-0.7499999999999999 1.0499999999999998,-2.65" data-type="line" data-label="" points="505.2941176470589,270.5882352941176 472.3529411764706,583.5294117647059" fill="none" stroke="hsl(75, 100%, 50%)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.45027,-2.275 2.25,-1.1999999999999997" data-type="line" data-label="" points="312.4732972972973,535.6756756756756 584.8648648648648,372.9729729729729" fill="none" stroke="hsl(75, 100%, 50%)" stroke-width="1" />
+    <polyline data-points="0.45027,-2.275 1.0499999999999998,-2.65" data-type="line" data-label="" points="373.5738823529412,521.7647058823529 472.3529411764706,583.5294117647059" fill="none" stroke="hsl(75, 100%, 50%)" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="OBS1" data-x="1.2" data-y="0.4" x="365.4054054054054" y="92.97297297297294" width="121.0810810810811" height="75.67567567567568" fill="rgba(0,0,0,0.1)" stroke="#555" stroke-width="0.0066071428571428574" />
+    <rect data-type="rect" data-label="OBS1" data-x="1.2" data-y="0.4" x="431.1764705882353" y="39.99999999999996" width="131.76470588235298" height="82.3529411764706" fill="rgba(0,0,0,0.1)" stroke="#555" stroke-width="0.006071428571428571" />
   </g>
   <g>
-    <rect data-type="rect" data-label="OBS2" data-x="-1" data-y="-0.6" x="39.99999999999997" y="229.18918918918916" width="105.94594594594597" height="105.94594594594594" fill="rgba(0,0,0,0.1)" stroke="#555" stroke-width="0.0066071428571428574" />
+    <rect data-type="rect" data-label="OBS2" data-x="-1" data-y="-0.6" x="77.05882352941177" y="188.23529411764704" width="115.29411764705884" height="115.29411764705881" fill="rgba(0,0,0,0.1)" stroke="#555" stroke-width="0.006071428571428571" />
   </g>
   <g>
     <rect data-type="rect" data-label="U1
-ccwRotationOffset: 0.0°" data-x="0.45000000000000007" data-y="-0.5999999999999999" x="176.21621621621622" y="236.75675675675672" width="272.4324324324324" height="90.81081081081078" fill="rgba(0,0,0,0.25)" stroke="black" stroke-width="0.0066071428571428574" />
+ccwRotationOffset: 0.0°" data-x="0.45000000000000007" data-y="-0.5999999999999999" x="225.29411764705884" y="196.47058823529406" width="296.4705882352941" height="98.82352941176472" fill="rgba(0,0,0,0.25)" stroke="black" stroke-width="0.006071428571428571" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1.1 NET_A" data-x="-0.35" data-y="-0.44999999999999984" x="176.21621621621622" y="244.32432432432427" width="30.27027027027026" height="30.27027027027026" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.0066071428571428574" />
+    <rect data-type="rect" data-label="U1.1 NET_A" data-x="-0.35" data-y="-0.44999999999999984" x="225.29411764705884" y="204.70588235294113" width="32.94117647058823" height="32.94117647058823" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.006071428571428571" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1.2 NET_B" data-x="1.25" data-y="-0.7499999999999999" x="418.37837837837833" y="289.7297297297297" width="30.270270270270316" height="30.27027027027026" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.0066071428571428574" />
+    <rect data-type="rect" data-label="U1.2 NET_B" data-x="1.25" data-y="-0.7499999999999999" x="488.82352941176475" y="254.11764705882348" width="32.941176470588175" height="32.94117647058823" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.006071428571428571" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1-body U1_body_disconnected" data-x="0.45000000000000007" data-y="-0.5999999999999999" x="221.62162162162164" y="236.75675675675672" width="181.62162162162159" height="90.81081081081078" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.0066071428571428574" />
+    <rect data-type="rect" data-label="U1-body U1_body_disconnected" data-x="0.45000000000000007" data-y="-0.5999999999999999" x="274.7058823529412" y="196.4705882352941" width="197.6470588235294" height="98.8235294117647" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.006071428571428571" />
   </g>
   <g>
     <rect data-type="rect" data-label="C1
-ccwRotationOffset: 0.0°" data-x="0.45" data-y="-1.7249999999999999" x="267.02702702702703" y="357.8378378378378" width="90.81081081081078" height="189.18918918918916" fill="rgba(0,0,0,0.25)" stroke="black" stroke-width="0.0066071428571428574" />
+ccwRotationOffset: 0.0°" data-x="0.45" data-y="-1.7249999999999999" x="324.11764705882354" y="328.2352941176471" width="98.82352941176475" height="205.88235294117635" fill="rgba(0,0,0,0.25)" stroke="black" stroke-width="0.006071428571428571" />
   </g>
   <g>
-    <rect data-type="rect" data-label="C1.1 NET_A" data-x="0.44973" data-y="-1.1749999999999998" x="301.0402162162162" y="357.8378378378378" width="22.70270270270271" height="22.70270270270271" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.0066071428571428574" />
+    <rect data-type="rect" data-label="C1.1 NET_A" data-x="0.44973" data-y="-1.1749999999999998" x="361.132" y="328.235294117647" width="24.705882352941217" height="24.70588235294116" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.006071428571428571" />
   </g>
   <g>
-    <rect data-type="rect" data-label="C1.2 NET_B" data-x="0.45027" data-y="-2.275" x="301.1219459459459" y="524.3243243243243" width="22.70270270270271" height="22.70270270270271" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.0066071428571428574" />
+    <rect data-type="rect" data-label="C1.2 NET_B" data-x="0.45027" data-y="-2.275" x="361.2209411764706" y="509.4117647058823" width="24.70588235294116" height="24.705882352941217" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.006071428571428571" />
   </g>
   <g>
-    <rect data-type="rect" data-label="C1-body C1_body_disconnected" data-x="0.45" data-y="-1.7249999999999999" x="267.02702702702703" y="369.18918918918916" width="90.81081081081078" height="166.48648648648646" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.0066071428571428574" />
+    <rect data-type="rect" data-label="C1-body C1_body_disconnected" data-x="0.45" data-y="-1.7249999999999999" x="324.11764705882354" y="340.58823529411757" width="98.82352941176475" height="181.17647058823536" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.006071428571428571" />
   </g>
   <g>
     <rect data-type="rect" data-label="R1
-ccwRotationOffset: 180.0°" data-x="1.65" data-y="-1.1999999999999997" x="388.1081081081081" y="357.83783783783775" width="211.89189189189187" height="30.270270270270316" fill="rgba(0,0,0,0.25)" stroke="black" stroke-width="0.0066071428571428574" />
+ccwRotationOffset: 180.0°" data-x="0.4499999999999999" data-y="-2.65" x="258.2352941176471" y="567.0588235294117" width="230.58823529411768" height="32.94117647058829" fill="rgba(0,0,0,0.25)" stroke="black" stroke-width="0.006071428571428571" />
   </g>
   <g>
-    <rect data-type="rect" data-label="R1.1 NET_B" data-x="2.25" data-y="-1.1999999999999997" x="569.7297297297298" y="357.83783783783775" width="30.270270270270203" height="30.270270270270316" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.0066071428571428574" />
+    <rect data-type="rect" data-label="R1.1 NET_B" data-x="1.0499999999999998" data-y="-2.65" x="455.88235294117646" y="567.0588235294117" width="32.94117647058829" height="32.94117647058829" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.006071428571428571" />
   </g>
   <g>
-    <rect data-type="rect" data-label="R1.2 NET_A" data-x="1.0499999999999998" data-y="-1.1999999999999997" x="388.1081081081081" y="357.83783783783775" width="30.270270270270203" height="30.270270270270316" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.0066071428571428574" />
+    <rect data-type="rect" data-label="R1.2 NET_A" data-x="-0.15000000000000008" data-y="-2.65" x="258.2352941176471" y="567.0588235294117" width="32.94117647058823" height="32.94117647058829" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.006071428571428571" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -88,12 +88,12 @@ ccwRotationOffset: 180.0°" data-x="1.65" data-y="-1.1999999999999997" x="388.10
 
       // Calculate real coordinates using inverse transformation
       const matrix = {
-        "a": 151.35135135135135,
+        "a": 164.7058823529412,
         "c": 0,
-        "e": 244.32432432432432,
+        "e": 299.4117647058824,
         "b": 0,
-        "d": -151.35135135135135,
-        "f": 191.35135135135133
+        "d": -164.7058823529412,
+        "f": 147.05882352941174
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:


### PR DESCRIPTION
## Summary
- accept `bounds` alias and clamp viable bounds to provided global bounds in OutlineSegmentCandidatePointSolver
- add tests ensuring candidate point solver honors global bounds
- update repro05 snapshot after bounds change

## Testing
- `bunx tsc --noEmit`
- `bun test tests`


------
https://chatgpt.com/codex/tasks/task_b_68c6e04bb52c832ebc62a606db4b0f84