### PR TITLE
Add boundary outline support to solvers and visualizations

### DIFF
--- a/lib/OutlineSegmentCandidatePointSolver/OutlineSegmentCandidatePointSolver.ts
+++ b/lib/OutlineSegmentCandidatePointSolver/OutlineSegmentCandidatePointSolver.ts
@@ -43,6 +43,7 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
   componentToPack: InputComponent
   viableBounds?: Bounds
   globalBounds?: Bounds
+  boundaryOutline?: Array<{ x: number; y: number }>
   optimalPosition?: Point
   irlsSolver?: MultiOffsetIrlsSolver
   twoPhaseIrlsSolver?: TwoPhaseIrlsSolver
@@ -57,6 +58,7 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
     componentToPack: InputComponent
     obstacles?: InputObstacle[]
     globalBounds?: Bounds
+    boundaryOutline?: Array<{ x: number; y: number }>
   }) {
     super()
     this.outlineSegment = params.outlineSegment
@@ -68,6 +70,7 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
     this.componentToPack = params.componentToPack
     this.obstacles = params.obstacles ?? []
     this.globalBounds = params.globalBounds
+    this.boundaryOutline = params.boundaryOutline
   }
 
   override getConstructorParams(): ConstructorParameters<
@@ -83,6 +86,7 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
       componentToPack: this.componentToPack,
       obstacles: this.obstacles,
       globalBounds: this.globalBounds,
+      boundaryOutline: this.boundaryOutline,
     }
   }
 
@@ -475,6 +479,23 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
         ],
         strokeColor: "rgba(255,0,255,0.5)",
         strokeDash: "2 2",
+      })
+    }
+
+    if (this.boundaryOutline && this.boundaryOutline.length) {
+      const outlinePoints = [...this.boundaryOutline]
+      if (
+        outlinePoints.length > 0 &&
+        (outlinePoints[0]!.x !== outlinePoints[outlinePoints.length - 1]!.x ||
+          outlinePoints[0]!.y !== outlinePoints[outlinePoints.length - 1]!.y)
+      ) {
+        outlinePoints.push({ ...outlinePoints[0]! })
+      }
+
+      graphics.lines!.push({
+        points: outlinePoints,
+        strokeColor: "rgba(0, 0, 255, 0.5)",
+        strokeDash: "4 2",
       })
     }
 

--- a/lib/PackSolver2/PackSolver2.ts
+++ b/lib/PackSolver2/PackSolver2.ts
@@ -88,6 +88,7 @@ export class PackSolver2 extends BaseSolver {
       minGap: this.packInput.minGap,
       obstacles: obstacles,
       bounds: this.packInput.bounds,
+      boundaryOutline: this.packInput.boundaryOutline,
     })
     fallbackSolver.solve()
     const result = fallbackSolver.getResult()
@@ -132,6 +133,7 @@ export class PackSolver2 extends BaseSolver {
         minGap: this.packInput.minGap,
         obstacles: this.packInput.obstacles ?? [],
         bounds: this.packInput.bounds,
+        boundaryOutline: this.packInput.boundaryOutline,
       })
       this.activeSubSolver.setup()
     }
@@ -208,6 +210,26 @@ export class PackSolver2 extends BaseSolver {
         ],
         strokeColor: "rgba(0,0,0,0.5)",
         strokeDash: "2 2",
+      })
+    }
+
+    if (
+      this.packInput.boundaryOutline &&
+      this.packInput.boundaryOutline.length
+    ) {
+      const points = [...this.packInput.boundaryOutline]
+      if (
+        points.length > 0 &&
+        (points[0]!.x !== points[points.length - 1]!.x ||
+          points[0]!.y !== points[points.length - 1]!.y)
+      ) {
+        points.push({ ...points[0]! })
+      }
+
+      graphics.lines!.push({
+        points,
+        strokeColor: "rgba(0, 0, 255, 0.5)",
+        strokeDash: "4 2",
       })
     }
 

--- a/lib/SingleComponentPackSolver/SingleComponentPackSolver.ts
+++ b/lib/SingleComponentPackSolver/SingleComponentPackSolver.ts
@@ -51,6 +51,7 @@ export class SingleComponentPackSolver extends BaseSolver {
   packPlacementStrategy: PackPlacementStrategy
   minGap: number
   obstacles: InputObstacle[]
+  boundaryOutline?: Array<{ x: number; y: number }>
 
   // Phase management
   currentPhase: Phase = "outline"
@@ -72,6 +73,7 @@ export class SingleComponentPackSolver extends BaseSolver {
     minGap?: number
     obstacles?: InputObstacle[]
     bounds?: Bounds
+    boundaryOutline?: Array<{ x: number; y: number }>
   }) {
     super()
     this.componentToPack = params.componentToPack
@@ -80,6 +82,7 @@ export class SingleComponentPackSolver extends BaseSolver {
     this.minGap = params.minGap ?? 0
     this.obstacles = params.obstacles ?? []
     this.bounds = params.bounds
+    this.boundaryOutline = params.boundaryOutline
   }
 
   override _setup() {
@@ -298,6 +301,7 @@ export class SingleComponentPackSolver extends BaseSolver {
         componentToPack: this.componentToPack,
         obstacles: this.obstacles,
         globalBounds: this.bounds,
+        boundaryOutline: this.boundaryOutline,
       })
 
       this.activeSubSolver.setup()
@@ -426,6 +430,23 @@ export class SingleComponentPackSolver extends BaseSolver {
         ],
         strokeColor: "rgba(0,0,0,0.5)",
         strokeDash: "2 2",
+      })
+    }
+
+    if (this.boundaryOutline && this.boundaryOutline.length) {
+      const outlinePoints = [...this.boundaryOutline]
+      if (
+        outlinePoints.length > 0 &&
+        (outlinePoints[0]!.x !== outlinePoints[outlinePoints.length - 1]!.x ||
+          outlinePoints[0]!.y !== outlinePoints[outlinePoints.length - 1]!.y)
+      ) {
+        outlinePoints.push({ ...outlinePoints[0]! })
+      }
+
+      graphics.lines!.push({
+        points: outlinePoints,
+        strokeColor: "rgba(0, 0, 255, 0.5)",
+        strokeDash: "4 2",
       })
     }
 
@@ -562,6 +583,7 @@ export class SingleComponentPackSolver extends BaseSolver {
       minGap: this.minGap,
       obstacles: this.obstacles,
       bounds: this.bounds,
+      boundaryOutline: this.boundaryOutline,
     }
   }
 }

--- a/lib/testing/getGraphicsFromPackOutput.ts
+++ b/lib/testing/getGraphicsFromPackOutput.ts
@@ -9,6 +9,23 @@ export const getGraphicsFromPackOutput = (
   const rects: Rect[] = []
   const lines: Line[] = []
 
+  if (packOutput.boundaryOutline && packOutput.boundaryOutline.length) {
+    const outlinePoints = [...packOutput.boundaryOutline]
+    if (
+      outlinePoints.length > 0 &&
+      (outlinePoints[0]!.x !== outlinePoints[outlinePoints.length - 1]!.x ||
+        outlinePoints[0]!.y !== outlinePoints[outlinePoints.length - 1]!.y)
+    ) {
+      outlinePoints.push({ ...outlinePoints[0]! })
+    }
+
+    lines.push({
+      points: outlinePoints,
+      strokeColor: "rgba(0, 0, 255, 0.5)",
+      strokeDash: "4 2",
+    } as Line)
+  }
+
   const allNetworkIds = Array.from(
     new Set(
       packOutput.components.flatMap((c) => c.pads.map((p) => p.networkId)),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -52,6 +52,8 @@ export interface PackInput {
 
   bounds?: { minX: number; minY: number; maxX: number; maxY: number }
 
+  boundaryOutline?: Array<{ x: number; y: number }>
+
   minGap: number
 
   packOrderStrategy: "largest_to_smallest"

--- a/site/repros/boundary-outline-debug.page.tsx
+++ b/site/repros/boundary-outline-debug.page.tsx
@@ -1,0 +1,120 @@
+import { PackDebugger } from "../components/PackDebugger"
+import type { PackInput } from "../../lib/types"
+
+const boundaryOutlinePackInput: PackInput = {
+  components: [
+    {
+      componentId: "U1",
+      availableRotationDegrees: [0],
+      pads: [
+        {
+          padId: "U1_P1",
+          networkId: "VCC",
+          type: "rect",
+          offset: { x: -5, y: 3 },
+          size: { x: 1.5, y: 1.5 },
+        },
+        {
+          padId: "U1_P2",
+          networkId: "GND",
+          type: "rect",
+          offset: { x: -5, y: -3 },
+          size: { x: 1.5, y: 1.5 },
+        },
+        {
+          padId: "U1_P3",
+          networkId: "IO1",
+          type: "rect",
+          offset: { x: 5, y: 3 },
+          size: { x: 1.5, y: 1.5 },
+        },
+        {
+          padId: "U1_P4",
+          networkId: "IO2",
+          type: "rect",
+          offset: { x: 5, y: -3 },
+          size: { x: 1.5, y: 1.5 },
+        },
+      ],
+    },
+    {
+      componentId: "U2",
+      availableRotationDegrees: [0],
+      pads: [
+        {
+          padId: "U2_P1",
+          networkId: "VCC",
+          type: "rect",
+          offset: { x: -3.5, y: 2 },
+          size: { x: 1.2, y: 1.2 },
+        },
+        {
+          padId: "U2_P2",
+          networkId: "GND",
+          type: "rect",
+          offset: { x: -3.5, y: -2 },
+          size: { x: 1.2, y: 1.2 },
+        },
+        {
+          padId: "U2_P3",
+          networkId: "IO3",
+          type: "rect",
+          offset: { x: 3.5, y: 0 },
+          size: { x: 1.2, y: 1.2 },
+        },
+      ],
+    },
+    {
+      componentId: "U3",
+      availableRotationDegrees: [0],
+      pads: [
+        {
+          padId: "U3_P1",
+          networkId: "VCC",
+          type: "rect",
+          offset: { x: 0, y: 4 },
+          size: { x: 1.2, y: 1.2 },
+        },
+        {
+          padId: "U3_P2",
+          networkId: "GND",
+          type: "rect",
+          offset: { x: 0, y: -4 },
+          size: { x: 1.2, y: 1.2 },
+        },
+      ],
+    },
+  ],
+  obstacles: [
+    {
+      obstacleId: "cutout",
+      absoluteCenter: { x: 0, y: 0 },
+      width: 8,
+      height: 6,
+    },
+  ],
+  boundaryOutline: [
+    { x: -50, y: -35 },
+    { x: 40, y: -35 },
+    { x: 55, y: 0 },
+    { x: 40, y: 35 },
+    { x: -50, y: 35 },
+    { x: -65, y: 0 },
+  ],
+  bounds: { minX: -70, minY: -45, maxX: 70, maxY: 45 },
+  minGap: 3,
+  packOrderStrategy: "largest_to_smallest",
+  packPlacementStrategy: "shortest_connection_along_outline",
+  disconnectedPackDirection: "nearest_to_center",
+}
+
+const BoundaryOutlineDebugPage = () => {
+  return (
+    <PackDebugger
+      initialPackInput={boundaryOutlinePackInput}
+      title="PackSolver2 Debugger – Boundary Outline Repro"
+    />
+  )
+}
+
+export default BoundaryOutlineDebugPage


### PR DESCRIPTION
## Summary
- add an optional `boundaryOutline` field to `PackInput` and propagate it into PackSolver2 and its sub-solvers
- visualize provided boundary outlines across PackSolver2, SingleComponentPackSolver, OutlineSegmentCandidatePointSolver, and `getGraphicsFromPackOutput`

## Testing
- bunx tsc --noEmit
- bun test tests/PackSolver2.test.ts
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68e30f7d8de4832e82734022c2b39ab5