### PR TITLE
Add courtyard support for component collision boundaries

### DIFF
--- a/lib/OutlineSegmentCandidatePointSolver/OutlineSegmentCandidatePointSolver.ts
+++ b/lib/OutlineSegmentCandidatePointSolver/OutlineSegmentCandidatePointSolver.ts
@@ -458,6 +458,7 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
           },
         }
       }),
+      courtyard: this.componentToPack.courtyard,
     }
   }
 

--- a/lib/PackSolver2/PackSolver2.ts
+++ b/lib/PackSolver2/PackSolver2.ts
@@ -11,6 +11,7 @@ import type {
 } from "../types"
 import { getColorForString } from "lib/testing/createColorMapFromStrings"
 import { computeDistanceBetweenBoxes } from "@tscircuit/math-utils"
+import { getComponentCollisionBoxes } from "./getComponentCollisionBoxes"
 import { getComponentBounds } from "../geometry/getComponentBounds"
 import { isPointInPolygon } from "../math/isPointInPolygon"
 import { getPolygonCentroid } from "../math/getPolygonCentroid"
@@ -108,19 +109,15 @@ export class PackSolver2 extends BaseSolver {
 
     // If there are obstacles, ensure at least minGap clearance; otherwise fall back to outline-based placement
     const obstacles = this.packInput.obstacles ?? []
+    const newComponentBoxes = getComponentCollisionBoxes(newPackedComponent)
     const tooCloseToObstacles = obstacles.some((obs) => {
       const obsBox = {
         center: { x: obs.absoluteCenter.x, y: obs.absoluteCenter.y },
         width: obs.width,
         height: obs.height,
       }
-      return newPackedComponent.pads.some((p) => {
-        const padBox = {
-          center: { x: p.absoluteCenter.x, y: p.absoluteCenter.y },
-          width: p.size.x,
-          height: p.size.y,
-        }
-        const { distance } = computeDistanceBetweenBoxes(padBox, obsBox)
+      return newComponentBoxes.some((box) => {
+        const { distance } = computeDistanceBetweenBoxes(box, obsBox)
         return distance + 1e-6 < this.packInput.minGap
       })
     })

--- a/lib/PackSolver2/checkOverlapWithPackedComponents.ts
+++ b/lib/PackSolver2/checkOverlapWithPackedComponents.ts
@@ -1,5 +1,6 @@
 import type { PackedComponent } from "../types"
 import { computeDistanceBetweenBoxes } from "@tscircuit/math-utils"
+import { getComponentCollisionBoxes } from "./getComponentCollisionBoxes"
 
 export interface CheckOverlapWithPackedComponentsParams {
   component: PackedComponent
@@ -15,24 +16,16 @@ export function checkOverlapWithPackedComponents({
   hasOverlap: boolean
   gapDistance?: number
 } {
-  const allPackedPadBoxes = packedComponents.flatMap((c) =>
-    c.pads.map((p) => ({
-      center: { x: p.absoluteCenter.x, y: p.absoluteCenter.y },
-      width: p.size.x,
-      height: p.size.y,
-    })),
+  const allPackedBoxes = packedComponents.flatMap((c) =>
+    getComponentCollisionBoxes(c),
   )
-  const newComponentPadBoxes = component.pads.map((p) => ({
-    center: { x: p.absoluteCenter.x, y: p.absoluteCenter.y },
-    width: p.size.x,
-    height: p.size.y,
-  }))
+  const newComponentBoxes = getComponentCollisionBoxes(component)
 
-  for (const newComponentPadBox of newComponentPadBoxes) {
-    for (const packedPadBox of allPackedPadBoxes) {
+  for (const newBox of newComponentBoxes) {
+    for (const packedBox of allPackedBoxes) {
       const { distance: boxDist } = computeDistanceBetweenBoxes(
-        newComponentPadBox,
-        packedPadBox,
+        newBox,
+        packedBox,
       )
       if (boxDist + 1e-6 < minGap) {
         return {

--- a/lib/PackSolver2/getComponentCollisionBoxes.ts
+++ b/lib/PackSolver2/getComponentCollisionBoxes.ts
@@ -1,0 +1,50 @@
+import type { PackedComponent } from "../types"
+import { rotatePoint } from "../math/rotatePoint"
+
+export interface CollisionBox {
+  center: { x: number; y: number }
+  width: number
+  height: number
+}
+
+/**
+ * Returns the collision boxes for a component. If the component has a
+ * courtyard, returns a single courtyard-derived box (rotated + translated).
+ * Otherwise, returns one box per pad (using absoluteCenter).
+ */
+export function getComponentCollisionBoxes(
+  component: PackedComponent,
+): CollisionBox[] {
+  if (component.courtyard) {
+    const courtyard = component.courtyard
+    const angleRad = (component.ccwRotationOffset * Math.PI) / 180
+    const rotatedOffset = rotatePoint(courtyard.offsetFromCenter, angleRad)
+
+    // For 90/270 degree rotations, swap width and height
+    const normalizedDeg = ((component.ccwRotationOffset % 360) + 360) % 360
+    const swapDims = normalizedDeg === 90 || normalizedDeg === 270
+    let width = courtyard.width
+    let height = courtyard.height
+    if (swapDims) {
+      width = courtyard.height
+      height = courtyard.width
+    }
+
+    return [
+      {
+        center: {
+          x: component.center.x + rotatedOffset.x,
+          y: component.center.y + rotatedOffset.y,
+        },
+        width,
+        height,
+      },
+    ]
+  }
+
+  return component.pads.map((p) => ({
+    center: { x: p.absoluteCenter.x, y: p.absoluteCenter.y },
+    width: p.size.x,
+    height: p.size.y,
+  }))
+}

--- a/lib/SingleComponentPackSolver/SingleComponentPackSolver.ts
+++ b/lib/SingleComponentPackSolver/SingleComponentPackSolver.ts
@@ -14,6 +14,7 @@ import type {
 } from "../types"
 import { isStrongConnection } from "../utils/isStrongConnection"
 import { checkOverlapWithPackedComponents } from "lib/PackSolver2/checkOverlapWithPackedComponents"
+import { getComponentCollisionBoxes } from "lib/PackSolver2/getComponentCollisionBoxes"
 import { computeDistanceBetweenBoxes, type Bounds } from "@tscircuit/math-utils"
 import { isPointInPolygon } from "lib/math/isPointInPolygon"
 import { getComponentBounds } from "lib/geometry/getComponentBounds"
@@ -133,19 +134,15 @@ export class SingleComponentPackSolver extends BaseSolver {
 
       // Build candidate at center and verify obstacle clearance
       const candidate = this.createPackedComponent(position, rotation)
+      const candidateBoxes = getComponentCollisionBoxes(candidate)
       const tooCloseToObstacles = (this.obstacles ?? []).some((obs) => {
         const obsBox = {
           center: { x: obs.absoluteCenter.x, y: obs.absoluteCenter.y },
           width: obs.width,
           height: obs.height,
         }
-        return candidate.pads.some((p) => {
-          const padBox = {
-            center: { x: p.absoluteCenter.x, y: p.absoluteCenter.y },
-            width: p.size.x,
-            height: p.size.y,
-          }
-          const { distance } = computeDistanceBetweenBoxes(padBox, obsBox)
+        return candidateBoxes.some((box) => {
+          const { distance } = computeDistanceBetweenBoxes(box, obsBox)
           return distance + 1e-6 < this.minGap
         })
       })
@@ -281,19 +278,16 @@ export class SingleComponentPackSolver extends BaseSolver {
 
         // Also ensure we keep minGap from any obstacles
         let minObstacleGapDistance = Infinity
+        const candidateCollisionBoxes =
+          getComponentCollisionBoxes(candidateComponent)
         const tooCloseToObstacles = (this.obstacles ?? []).some((obs) => {
           const obsBox = {
             center: { x: obs.absoluteCenter.x, y: obs.absoluteCenter.y },
             width: obs.width,
             height: obs.height,
           }
-          return candidateComponent.pads.some((p) => {
-            const padBox = {
-              center: { x: p.absoluteCenter.x, y: p.absoluteCenter.y },
-              width: p.size.x,
-              height: p.size.y,
-            }
-            const { distance } = computeDistanceBetweenBoxes(padBox, obsBox)
+          return candidateCollisionBoxes.some((box) => {
+            const { distance } = computeDistanceBetweenBoxes(box, obsBox)
             minObstacleGapDistance = Math.min(minObstacleGapDistance, distance)
             return distance + 1e-6 < this.minGap
           })

--- a/lib/constructOutlinesFromPackedComponents.ts
+++ b/lib/constructOutlinesFromPackedComponents.ts
@@ -5,7 +5,11 @@ import { getComponentBounds } from "./geometry/getComponentBounds"
 import { simplifyCollinearSegments } from "./geometry/simplify-collinear-segments"
 import { rotatePoint } from "./math/rotatePoint"
 import { parseFlattenPolygonSegments } from "./parseFlattenPolygonLoops"
-import type { InputObstacle, PackedComponent } from "./types"
+import type {
+  ComponentCourtyard,
+  InputObstacle,
+  PackedComponent,
+} from "./types"
 
 type Outline = Array<[Point, Point]>
 
@@ -27,6 +31,64 @@ export interface ConstructedOutlines {
    * Components should be placed outside these boundaries.
    */
   obstacleContainingLoops: Outline[]
+}
+
+/**
+ * Create a single polygon from a courtyard (inflated by minGap),
+ * positioned and rotated according to the component's placement.
+ */
+const createCourtyardPolygon = (opts: {
+  component: PackedComponent
+  courtyard: ComponentCourtyard
+  minGap: number
+}): PadShape => {
+  const { component, courtyard, minGap } = opts
+  const hw = courtyard.width / 2 + minGap
+  const hh = courtyard.height / 2 + minGap
+
+  const localCorners = [
+    {
+      x: courtyard.offsetFromCenter.x - hw,
+      y: courtyard.offsetFromCenter.y - hh,
+    },
+    {
+      x: courtyard.offsetFromCenter.x + hw,
+      y: courtyard.offsetFromCenter.y - hh,
+    },
+    {
+      x: courtyard.offsetFromCenter.x + hw,
+      y: courtyard.offsetFromCenter.y + hh,
+    },
+    {
+      x: courtyard.offsetFromCenter.x - hw,
+      y: courtyard.offsetFromCenter.y + hh,
+    },
+  ]
+
+  const worldCorners = localCorners.map((corner) => {
+    const rotated = rotatePoint(
+      corner,
+      (component.ccwRotationOffset * Math.PI) / 180,
+    )
+    return {
+      x: rotated.x + component.center.x,
+      y: rotated.y + component.center.y,
+    }
+  })
+
+  const arr = worldCorners.map(({ x, y }) => [x, y] as [number, number])
+  const poly = new Flatten.Polygon(arr)
+
+  const xs = worldCorners.map((p) => p.x)
+  const ys = worldCorners.map((p) => p.y)
+  const bbox = {
+    minX: Math.min(...xs),
+    minY: Math.min(...ys),
+    maxX: Math.max(...xs),
+    maxY: Math.max(...ys),
+  }
+
+  return { poly, bbox }
 }
 
 /**
@@ -142,8 +204,18 @@ export const constructOutlinesFromPackedComponents = (
   // Build pad polygons (inflated by minGap) and obstacle polygons
   const allPadShapes: PadShape[] = []
   for (const component of components) {
-    const padShapes = createPadPolygons(component, minGap)
-    allPadShapes.push(...padShapes)
+    if (component.courtyard) {
+      allPadShapes.push(
+        createCourtyardPolygon({
+          component,
+          courtyard: component.courtyard,
+          minGap,
+        }),
+      )
+    } else {
+      const padShapes = createPadPolygons(component, minGap)
+      allPadShapes.push(...padShapes)
+    }
   }
   const obstacleShapes = createObstaclePolygons(obstacles, minGap)
   allPadShapes.push(...obstacleShapes)
@@ -258,8 +330,18 @@ export const constructSemanticOutlinesFromPackedComponents = (
   // Build pad polygons (inflated by minGap) and obstacle polygons
   const allPadShapes: PadShape[] = []
   for (const component of components) {
-    const padShapes = createPadPolygons(component, minGap)
-    allPadShapes.push(...padShapes)
+    if (component.courtyard) {
+      allPadShapes.push(
+        createCourtyardPolygon({
+          component,
+          courtyard: component.courtyard,
+          minGap,
+        }),
+      )
+    } else {
+      const padShapes = createPadPolygons(component, minGap)
+      allPadShapes.push(...padShapes)
+    }
   }
   const obstacleShapes = createObstaclePolygons(obstacles, minGap)
   allPadShapes.push(...obstacleShapes)

--- a/lib/geometry/expandRotatedRectIntoBounds.ts
+++ b/lib/geometry/expandRotatedRectIntoBounds.ts
@@ -1,0 +1,38 @@
+import type { Bounds } from "@tscircuit/math-utils"
+import { rotatePoint } from "../math/rotatePoint"
+
+/**
+ * Expand `bounds` to include all four corners of a rectangle after rotation
+ * and optional translation. Mutates `bounds` in place.
+ */
+export function expandRotatedRectIntoBounds(opts: {
+  bounds: Bounds
+  center: { x: number; y: number }
+  width: number
+  height: number
+  angleRad: number
+  translate?: { x: number; y: number }
+}): void {
+  const { bounds, center, width, height, angleRad } = opts
+  const tx = opts.translate?.x ?? 0
+  const ty = opts.translate?.y ?? 0
+  const hw = width / 2
+  const hh = height / 2
+
+  const corners = [
+    { x: center.x - hw, y: center.y - hh },
+    { x: center.x + hw, y: center.y - hh },
+    { x: center.x + hw, y: center.y + hh },
+    { x: center.x - hw, y: center.y + hh },
+  ]
+
+  for (const corner of corners) {
+    const rotated = rotatePoint(corner, angleRad)
+    const x = rotated.x + tx
+    const y = rotated.y + ty
+    bounds.minX = Math.min(bounds.minX, x)
+    bounds.maxX = Math.max(bounds.maxX, x)
+    bounds.minY = Math.min(bounds.minY, y)
+    bounds.maxY = Math.max(bounds.maxY, y)
+  }
+}

--- a/lib/geometry/getComponentBounds.ts
+++ b/lib/geometry/getComponentBounds.ts
@@ -1,12 +1,6 @@
+import type { Bounds } from "@tscircuit/math-utils"
 import type { PackedComponent } from "../types"
-import { rotatePoint } from "../math/rotatePoint"
-
-export interface Bounds {
-  minX: number
-  maxX: number
-  minY: number
-  maxY: number
-}
+import { expandRotatedRectIntoBounds } from "./expandRotatedRectIntoBounds"
 
 /** Axis-aligned bounds of a component, expanded by `minGap`. */
 export const getComponentBounds = (
@@ -20,64 +14,28 @@ export const getComponentBounds = (
     maxY: -Infinity,
   }
 
-  component.pads.forEach((pad) => {
-    const hw = pad.size.x / 2
-    const hh = pad.size.y / 2
-    const localCorners = [
-      { x: pad.offset.x - hw, y: pad.offset.y - hh },
-      { x: pad.offset.x + hw, y: pad.offset.y - hh },
-      { x: pad.offset.x + hw, y: pad.offset.y + hh },
-      { x: pad.offset.x - hw, y: pad.offset.y + hh },
-    ]
+  const angleRad = (component.ccwRotationOffset * Math.PI) / 180
 
-    localCorners.forEach((corner) => {
-      const world = rotatePoint(
-        corner,
-        (component.ccwRotationOffset * Math.PI) / 180,
-      ) // Convert to radians for math
-      const x = world.x + component.center.x
-      const y = world.y + component.center.y
-      bounds.minX = Math.min(bounds.minX, x)
-      bounds.maxX = Math.max(bounds.maxX, x)
-      bounds.minY = Math.min(bounds.minY, y)
-      bounds.maxY = Math.max(bounds.maxY, y)
+  for (const pad of component.pads) {
+    expandRotatedRectIntoBounds({
+      bounds,
+      center: pad.offset,
+      width: pad.size.x,
+      height: pad.size.y,
+      angleRad,
+      translate: component.center,
     })
-  })
+  }
 
   if (component.courtyard) {
-    const courtyard = component.courtyard
-    const hw = courtyard.width / 2
-    const hh = courtyard.height / 2
-    const localCorners = [
-      {
-        x: courtyard.offsetFromCenter.x - hw,
-        y: courtyard.offsetFromCenter.y - hh,
-      },
-      {
-        x: courtyard.offsetFromCenter.x + hw,
-        y: courtyard.offsetFromCenter.y - hh,
-      },
-      {
-        x: courtyard.offsetFromCenter.x + hw,
-        y: courtyard.offsetFromCenter.y + hh,
-      },
-      {
-        x: courtyard.offsetFromCenter.x - hw,
-        y: courtyard.offsetFromCenter.y + hh,
-      },
-    ]
-    for (const corner of localCorners) {
-      const world = rotatePoint(
-        corner,
-        (component.ccwRotationOffset * Math.PI) / 180,
-      )
-      const x = world.x + component.center.x
-      const y = world.y + component.center.y
-      bounds.minX = Math.min(bounds.minX, x)
-      bounds.maxX = Math.max(bounds.maxX, x)
-      bounds.minY = Math.min(bounds.minY, y)
-      bounds.maxY = Math.max(bounds.maxY, y)
-    }
+    expandRotatedRectIntoBounds({
+      bounds,
+      center: component.courtyard.offsetFromCenter,
+      width: component.courtyard.width,
+      height: component.courtyard.height,
+      angleRad,
+      translate: component.center,
+    })
   }
 
   return {

--- a/lib/geometry/getComponentBounds.ts
+++ b/lib/geometry/getComponentBounds.ts
@@ -44,6 +44,42 @@ export const getComponentBounds = (
     })
   })
 
+  if (component.courtyard) {
+    const courtyard = component.courtyard
+    const hw = courtyard.width / 2
+    const hh = courtyard.height / 2
+    const localCorners = [
+      {
+        x: courtyard.offsetFromCenter.x - hw,
+        y: courtyard.offsetFromCenter.y - hh,
+      },
+      {
+        x: courtyard.offsetFromCenter.x + hw,
+        y: courtyard.offsetFromCenter.y - hh,
+      },
+      {
+        x: courtyard.offsetFromCenter.x + hw,
+        y: courtyard.offsetFromCenter.y + hh,
+      },
+      {
+        x: courtyard.offsetFromCenter.x - hw,
+        y: courtyard.offsetFromCenter.y + hh,
+      },
+    ]
+    for (const corner of localCorners) {
+      const world = rotatePoint(
+        corner,
+        (component.ccwRotationOffset * Math.PI) / 180,
+      )
+      const x = world.x + component.center.x
+      const y = world.y + component.center.y
+      bounds.minX = Math.min(bounds.minX, x)
+      bounds.maxX = Math.max(bounds.maxX, x)
+      bounds.minY = Math.min(bounds.minY, y)
+      bounds.maxY = Math.max(bounds.maxY, y)
+    }
+  }
+
   return {
     minX: bounds.minX - minGap,
     maxX: bounds.maxX + minGap,

--- a/lib/geometry/getInputComponentBounds.ts
+++ b/lib/geometry/getInputComponentBounds.ts
@@ -34,6 +34,37 @@ export const getInputComponentBounds = (
     }
   }
 
+  if (component.courtyard) {
+    const courtyard = component.courtyard
+    const hw = courtyard.width / 2
+    const hh = courtyard.height / 2
+    const localCorners = [
+      {
+        x: courtyard.offsetFromCenter.x - hw,
+        y: courtyard.offsetFromCenter.y - hh,
+      },
+      {
+        x: courtyard.offsetFromCenter.x + hw,
+        y: courtyard.offsetFromCenter.y - hh,
+      },
+      {
+        x: courtyard.offsetFromCenter.x + hw,
+        y: courtyard.offsetFromCenter.y + hh,
+      },
+      {
+        x: courtyard.offsetFromCenter.x - hw,
+        y: courtyard.offsetFromCenter.y + hh,
+      },
+    ]
+    for (const corner of localCorners) {
+      const world = rotatePoint(corner, (rotationDegrees * Math.PI) / 180)
+      bounds.minX = Math.min(bounds.minX, world.x)
+      bounds.maxX = Math.max(bounds.maxX, world.x)
+      bounds.minY = Math.min(bounds.minY, world.y)
+      bounds.maxY = Math.max(bounds.maxY, world.y)
+    }
+  }
+
   return {
     minX: bounds.minX,
     maxX: bounds.maxX,

--- a/lib/geometry/getInputComponentBounds.ts
+++ b/lib/geometry/getInputComponentBounds.ts
@@ -1,6 +1,6 @@
-import type { InputComponent, PackedComponent } from "../types"
-import { rotatePoint } from "../math/rotatePoint"
+import type { InputComponent } from "../types"
 import type { Bounds } from "@tscircuit/math-utils"
+import { expandRotatedRectIntoBounds } from "./expandRotatedRectIntoBounds"
 
 export const getInputComponentBounds = (
   component: InputComponent,
@@ -13,62 +13,27 @@ export const getInputComponentBounds = (
     maxY: -Infinity,
   }
 
-  for (const pad of component.pads) {
-    const hw = pad.size.x / 2
-    const hh = pad.size.y / 2
-    const localCorners = [
-      { x: pad.offset.x - hw, y: pad.offset.y - hh },
-      { x: pad.offset.x + hw, y: pad.offset.y - hh },
-      { x: pad.offset.x + hw, y: pad.offset.y + hh },
-      { x: pad.offset.x - hw, y: pad.offset.y + hh },
-    ]
+  const angleRad = (rotationDegrees * Math.PI) / 180
 
-    for (const corner of localCorners) {
-      const world = rotatePoint(corner, (rotationDegrees * Math.PI) / 180) // Convert to radians for math
-      const x = world.x
-      const y = world.y
-      bounds.minX = Math.min(bounds.minX, x)
-      bounds.maxX = Math.max(bounds.maxX, x)
-      bounds.minY = Math.min(bounds.minY, y)
-      bounds.maxY = Math.max(bounds.maxY, y)
-    }
+  for (const pad of component.pads) {
+    expandRotatedRectIntoBounds({
+      bounds,
+      center: pad.offset,
+      width: pad.size.x,
+      height: pad.size.y,
+      angleRad,
+    })
   }
 
   if (component.courtyard) {
-    const courtyard = component.courtyard
-    const hw = courtyard.width / 2
-    const hh = courtyard.height / 2
-    const localCorners = [
-      {
-        x: courtyard.offsetFromCenter.x - hw,
-        y: courtyard.offsetFromCenter.y - hh,
-      },
-      {
-        x: courtyard.offsetFromCenter.x + hw,
-        y: courtyard.offsetFromCenter.y - hh,
-      },
-      {
-        x: courtyard.offsetFromCenter.x + hw,
-        y: courtyard.offsetFromCenter.y + hh,
-      },
-      {
-        x: courtyard.offsetFromCenter.x - hw,
-        y: courtyard.offsetFromCenter.y + hh,
-      },
-    ]
-    for (const corner of localCorners) {
-      const world = rotatePoint(corner, (rotationDegrees * Math.PI) / 180)
-      bounds.minX = Math.min(bounds.minX, world.x)
-      bounds.maxX = Math.max(bounds.maxX, world.x)
-      bounds.minY = Math.min(bounds.minY, world.y)
-      bounds.maxY = Math.max(bounds.maxY, world.y)
-    }
+    expandRotatedRectIntoBounds({
+      bounds,
+      center: component.courtyard.offsetFromCenter,
+      width: component.courtyard.width,
+      height: component.courtyard.height,
+      angleRad,
+    })
   }
 
-  return {
-    minX: bounds.minX,
-    maxX: bounds.maxX,
-    minY: bounds.minY,
-    maxY: bounds.maxY,
-  }
+  return bounds
 }

--- a/lib/plumbing/convertCircuitJsonToPackOutput.ts
+++ b/lib/plumbing/convertCircuitJsonToPackOutput.ts
@@ -6,10 +6,79 @@ import type {
   PackInput,
   PackOutput,
   InputObstacle,
+  ComponentCourtyard,
 } from "../types"
 import { extractPadInfos } from "./extractPadInfos"
 import { getElementOutsideTree } from "./getElementsOutsideTree"
 import { getObstacleFromElement } from "./getObstacleFromElement"
+
+/**
+ * Extract a bounding-box courtyard for a set of pcb_component_ids from the
+ * raw circuit-json array. Supports pcb_courtyard_rect, pcb_courtyard_polygon,
+ * and pcb_courtyard_outline element types.
+ */
+const extractCourtyardForComponent = (opts: {
+  circuitJson: CircuitJson
+  pcbComponentIds: string[]
+  componentCenter: { x: number; y: number }
+}): ComponentCourtyard | undefined => {
+  const { circuitJson, pcbComponentIds, componentCenter } = opts
+  const idSet = new Set(pcbComponentIds)
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  let found = false
+
+  for (const el of circuitJson as Array<Record<string, unknown>>) {
+    if (
+      typeof el.pcb_component_id !== "string" ||
+      !idSet.has(el.pcb_component_id)
+    )
+      continue
+
+    if (el.type === "pcb_courtyard_rect") {
+      const center = el.center as { x: number; y: number }
+      const width = el.width as number
+      const height = el.height as number
+      minX = Math.min(minX, center.x - width / 2)
+      maxX = Math.max(maxX, center.x + width / 2)
+      minY = Math.min(minY, center.y - height / 2)
+      maxY = Math.max(maxY, center.y + height / 2)
+      found = true
+    } else if (el.type === "pcb_courtyard_polygon") {
+      for (const pt of el.points as Array<{ x: number; y: number }>) {
+        minX = Math.min(minX, pt.x)
+        maxX = Math.max(maxX, pt.x)
+        minY = Math.min(minY, pt.y)
+        maxY = Math.max(maxY, pt.y)
+      }
+      found = true
+    } else if (el.type === "pcb_courtyard_outline") {
+      for (const pt of el.outline as Array<{ x: number; y: number }>) {
+        minX = Math.min(minX, pt.x)
+        maxX = Math.max(maxX, pt.x)
+        minY = Math.min(minY, pt.y)
+        maxY = Math.max(maxY, pt.y)
+      }
+      found = true
+    }
+  }
+
+  if (!found) return undefined
+
+  const courtyardCenterX = (minX + maxX) / 2
+  const courtyardCenterY = (minY + maxY) / 2
+
+  return {
+    offsetFromCenter: {
+      x: courtyardCenterX - componentCenter.x,
+      y: courtyardCenterY - componentCenter.y,
+    },
+    width: maxX - minX,
+    height: maxY - minY,
+  }
+}
 
 /* build a single PackedComponent from one or more pcb_components */
 const buildPackedComponent = (
@@ -24,6 +93,7 @@ const buildPackedComponent = (
     { left: number; right: number; top: number; bottom: number }
   > = {},
   isStatic = false,
+  circuitJson?: CircuitJson,
 ): PackedComponent => {
   const padInfos = pcbComponents.flatMap((pc) => {
     const pads = extractPadInfos(pc, db, getNetworkId)
@@ -92,12 +162,22 @@ const buildPackedComponent = (
     pads.push(innerPad)
   }
 
+  let courtyard: ComponentCourtyard | undefined
+  if (circuitJson) {
+    courtyard = extractCourtyardForComponent({
+      circuitJson,
+      pcbComponentIds: pcbComponents.map((pc) => pc.pcb_component_id),
+      componentCenter: center,
+    })
+  }
+
   return {
     componentId,
     isStatic,
     center,
     ccwRotationOffset: 0,
     pads,
+    courtyard,
   } as PackedComponent
 }
 
@@ -225,6 +305,7 @@ export const convertCircuitJsonToPackOutput = (
           sourcePortToPadIds,
           opts.chipMarginsMap,
           staticComponentIds.has(pcbComponent.pcb_component_id),
+          circuitJson,
         ),
       )
     } else if (node.nodeType === "group") {
@@ -244,6 +325,7 @@ export const convertCircuitJsonToPackOutput = (
           sourcePortToPadIds,
           opts.chipMarginsMap,
           staticComponentIds.has(compId),
+          circuitJson,
         ),
       )
     }

--- a/lib/plumbing/convertCircuitJsonToPackOutput.ts
+++ b/lib/plumbing/convertCircuitJsonToPackOutput.ts
@@ -13,16 +13,16 @@ import { getElementOutsideTree } from "./getElementsOutsideTree"
 import { getObstacleFromElement } from "./getObstacleFromElement"
 
 /**
- * Extract a bounding-box courtyard for a set of pcb_component_ids from the
- * raw circuit-json array. Supports pcb_courtyard_rect, pcb_courtyard_polygon,
- * and pcb_courtyard_outline element types.
+ * Extract a bounding-box courtyard for a set of pcb_component_ids using the db.
+ * Supports pcb_courtyard_rect, pcb_courtyard_polygon, pcb_courtyard_outline,
+ * and pcb_courtyard_circle.
  */
 const extractCourtyardForComponent = (opts: {
-  circuitJson: CircuitJson
+  db: ReturnType<typeof cju>
   pcbComponentIds: string[]
   componentCenter: { x: number; y: number }
 }): ComponentCourtyard | undefined => {
-  const { circuitJson, pcbComponentIds, componentCenter } = opts
+  const { db, pcbComponentIds, componentCenter } = opts
   const idSet = new Set(pcbComponentIds)
   let minX = Infinity
   let minY = Infinity
@@ -30,39 +30,44 @@ const extractCourtyardForComponent = (opts: {
   let maxY = -Infinity
   let found = false
 
-  for (const el of circuitJson as Array<Record<string, unknown>>) {
-    if (
-      typeof el.pcb_component_id !== "string" ||
-      !idSet.has(el.pcb_component_id)
-    )
-      continue
+  for (const rect of db.pcb_courtyard_rect.list()) {
+    if (!idSet.has(rect.pcb_component_id)) continue
+    minX = Math.min(minX, rect.center.x - rect.width / 2)
+    maxX = Math.max(maxX, rect.center.x + rect.width / 2)
+    minY = Math.min(minY, rect.center.y - rect.height / 2)
+    maxY = Math.max(maxY, rect.center.y + rect.height / 2)
+    found = true
+  }
 
-    if (el.type === "pcb_courtyard_rect") {
-      const center = el.center as { x: number; y: number }
-      const width = el.width as number
-      const height = el.height as number
-      minX = Math.min(minX, center.x - width / 2)
-      maxX = Math.max(maxX, center.x + width / 2)
-      minY = Math.min(minY, center.y - height / 2)
-      maxY = Math.max(maxY, center.y + height / 2)
-      found = true
-    } else if (el.type === "pcb_courtyard_polygon") {
-      for (const pt of el.points as Array<{ x: number; y: number }>) {
-        minX = Math.min(minX, pt.x)
-        maxX = Math.max(maxX, pt.x)
-        minY = Math.min(minY, pt.y)
-        maxY = Math.max(maxY, pt.y)
-      }
-      found = true
-    } else if (el.type === "pcb_courtyard_outline") {
-      for (const pt of el.outline as Array<{ x: number; y: number }>) {
-        minX = Math.min(minX, pt.x)
-        maxX = Math.max(maxX, pt.x)
-        minY = Math.min(minY, pt.y)
-        maxY = Math.max(maxY, pt.y)
-      }
-      found = true
+  for (const polygon of db.pcb_courtyard_polygon.list()) {
+    if (!idSet.has(polygon.pcb_component_id)) continue
+    for (const pt of polygon.points) {
+      minX = Math.min(minX, pt.x)
+      maxX = Math.max(maxX, pt.x)
+      minY = Math.min(minY, pt.y)
+      maxY = Math.max(maxY, pt.y)
     }
+    found = true
+  }
+
+  for (const outline of db.pcb_courtyard_outline.list()) {
+    if (!idSet.has(outline.pcb_component_id)) continue
+    for (const pt of outline.outline) {
+      minX = Math.min(minX, pt.x)
+      maxX = Math.max(maxX, pt.x)
+      minY = Math.min(minY, pt.y)
+      maxY = Math.max(maxY, pt.y)
+    }
+    found = true
+  }
+
+  for (const circle of db.pcb_courtyard_circle.list()) {
+    if (!idSet.has(circle.pcb_component_id)) continue
+    minX = Math.min(minX, circle.center.x - circle.radius)
+    maxX = Math.max(maxX, circle.center.x + circle.radius)
+    minY = Math.min(minY, circle.center.y - circle.radius)
+    maxY = Math.max(maxY, circle.center.y + circle.radius)
+    found = true
   }
 
   if (!found) return undefined
@@ -93,7 +98,6 @@ const buildPackedComponent = (
     { left: number; right: number; top: number; bottom: number }
   > = {},
   isStatic = false,
-  circuitJson?: CircuitJson,
 ): PackedComponent => {
   const padInfos = pcbComponents.flatMap((pc) => {
     const pads = extractPadInfos(pc, db, getNetworkId)
@@ -162,14 +166,11 @@ const buildPackedComponent = (
     pads.push(innerPad)
   }
 
-  let courtyard: ComponentCourtyard | undefined
-  if (circuitJson) {
-    courtyard = extractCourtyardForComponent({
-      circuitJson,
-      pcbComponentIds: pcbComponents.map((pc) => pc.pcb_component_id),
-      componentCenter: center,
-    })
-  }
+  const courtyard = extractCourtyardForComponent({
+    db,
+    pcbComponentIds: pcbComponents.map((pc) => pc.pcb_component_id),
+    componentCenter: center,
+  })
 
   return {
     componentId,
@@ -305,7 +306,6 @@ export const convertCircuitJsonToPackOutput = (
           sourcePortToPadIds,
           opts.chipMarginsMap,
           staticComponentIds.has(pcbComponent.pcb_component_id),
-          circuitJson,
         ),
       )
     } else if (node.nodeType === "group") {
@@ -325,7 +325,6 @@ export const convertCircuitJsonToPackOutput = (
           sourcePortToPadIds,
           opts.chipMarginsMap,
           staticComponentIds.has(compId),
-          circuitJson,
         ),
       )
     }

--- a/lib/plumbing/convertPackOutputToPackInput.ts
+++ b/lib/plumbing/convertPackOutputToPackInput.ts
@@ -24,6 +24,7 @@ export const convertPackOutputToPackInput = (packed: PackOutput): PackInput => {
           componentId: pc.componentId,
           availableRotationDegrees: pc.availableRotationDegrees, // Preserve rotation constraints
           pads: pc.pads.map(({ absoluteCenter: _ac, ...rest }) => rest),
+          courtyard: pc.courtyard,
         }),
   }))
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -15,6 +15,12 @@ export interface OutputPad extends InputPad {
   absoluteCenter: { x: number; y: number }
 }
 
+export interface ComponentCourtyard {
+  offsetFromCenter: { x: number; y: number }
+  width: number
+  height: number
+}
+
 export interface InputComponent {
   componentId: string
   /** Components marked as static are not moved by the packer */
@@ -28,6 +34,8 @@ export interface InputComponent {
   /** Preconfigured rotation (degrees CCW) for static components */
   ccwRotationOffset?: number
   pads: InputPad[]
+  /** Optional courtyard defining the component's physical boundary */
+  courtyard?: ComponentCourtyard
 }
 
 export interface PackedComponent extends InputComponent {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^5.0.0",
     "bun-match-svg": "^0.0.12",
-    "circuit-json": "^0.0.309",
+    "circuit-json": "^0.0.421",
     "framer-motion": "^12.23.12",
     "graphics-debug": "^0.0.78",
     "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@biomejs/biome": "^2.1.1",
     "@flatten-js/core": "^1.6.2",
     "@react-hook/resize-observer": "^2.0.2",
-    "@tscircuit/circuit-json-util": "^0.0.66",
+    "@tscircuit/circuit-json-util": "^0.0.94",
     "@tscircuit/footprinter": "^0.0.203",
     "@tscircuit/math-utils": "^0.0.25",
     "@tscircuit/solver-utils": "^0.0.14",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@react-hook/resize-observer": "^2.0.2",
     "@tscircuit/circuit-json-util": "^0.0.94",
     "@tscircuit/footprinter": "^0.0.203",
-    "@tscircuit/math-utils": "^0.0.25",
+    "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/solver-utils": "^0.0.14",
     "@types/bun": "latest",
     "@types/react": "^19.1.8",

--- a/tests/__snapshots__/courtyard-clearance.visual.snap.svg
+++ b/tests/__snapshots__/courtyard-clearance.visual.snap.svg
@@ -1,0 +1,46 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-0.6,0 -0.6,-4.5" data-type="line" data-label="" points="280.47058823529414,171.76470588235296 280.47058823529414,468.2352941176471" fill="none" stroke="hsl(0, 100%, 50%)" stroke-width="1px"/></g><g><polyline data-points="0.6,0 0.6,-4.5" data-type="line" data-label="" points="359.52941176470586,171.76470588235296 359.52941176470586,468.2352941176471" fill="none" stroke="hsl(150, 100%, 50%)" stroke-width="1px"/></g><g><rect data-type="rect" data-label="U1
+ccwRotationOffset: 0.0°" data-x="0" data-y="0" x="56.470588235294144" y="40.00000000000003" width="527.0588235294117" height="263.52941176470586" fill="rgba(0,0,0,0.25)" stroke="black" stroke-width="0.01517857142857143"/></g><g><rect data-type="rect" data-label="U1_1 SIG_A" data-x="-0.6" data-y="0" x="247.52941176470588" y="138.82352941176472" width="65.88235294117649" height="65.88235294117646" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.01517857142857143"/></g><g><rect data-type="rect" data-label="U1_2 SIG_B" data-x="0.6" data-y="0" x="326.5882352941176" y="138.82352941176472" width="65.88235294117652" height="65.88235294117646" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.01517857142857143"/></g><g><rect data-type="rect" data-label="U2
+ccwRotationOffset: 180.0°" data-x="0" data-y="-4.5" x="56.470588235294144" y="336.47058823529414" width="527.0588235294117" height="263.52941176470586" fill="rgba(0,0,0,0.25)" stroke="black" stroke-width="0.01517857142857143"/></g><g><rect data-type="rect" data-label="U2_1 SIG_A" data-x="-0.6" data-y="-4.5" x="247.52941176470588" y="435.2941176470588" width="65.88235294117649" height="65.88235294117646" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.01517857142857143"/></g><g><rect data-type="rect" data-label="U2_2 SIG_B" data-x="0.6" data-y="-4.5" x="326.5882352941176" y="435.2941176470588" width="65.88235294117652" height="65.88235294117646" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.01517857142857143"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":65.88235294117646,"c":0,"e":320,"b":0,"d":-65.88235294117646,"f":171.76470588235296};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/courtyard-clearance.visual.test.ts
+++ b/tests/courtyard-clearance.visual.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { getSvgFromGraphicsObject } from "graphics-debug"
+import { pack } from "../lib/pack"
+import { getGraphicsFromPackOutput } from "../lib/testing/getGraphicsFromPackOutput"
+import { courtyardClearancePackInput } from "./courtyard-clearance/packInput"
+import { checkOverlapWithPackedComponents } from "../lib/PackSolver2/checkOverlapWithPackedComponents"
+
+test("courtyard clearance - visual regression", () => {
+  const output = pack(courtyardClearancePackInput)
+
+  const u1 = output.components.find((c) => c.componentId === "U1")!
+  const u2 = output.components.find((c) => c.componentId === "U2")!
+  const overlap = checkOverlapWithPackedComponents({
+    component: u2,
+    packedComponents: [u1],
+    minGap: courtyardClearancePackInput.minGap,
+  })
+  expect(overlap.hasOverlap).toBe(false)
+
+  const graphics = getGraphicsFromPackOutput(output)
+
+  expect(
+    getSvgFromGraphicsObject(graphics, {
+      backgroundColor: "white",
+    }),
+  ).toMatchSvgSnapshot(import.meta.path)
+})

--- a/tests/courtyard-clearance/packInput.ts
+++ b/tests/courtyard-clearance/packInput.ts
@@ -1,0 +1,57 @@
+import type { PackInput } from "../../lib/types"
+
+export const courtyardClearancePackInput: PackInput = {
+  components: [
+    {
+      componentId: "U1",
+      pads: [
+        {
+          padId: "U1_1",
+          networkId: "SIG_A",
+          type: "rect",
+          offset: { x: -0.6, y: 0 },
+          size: { x: 1, y: 1 },
+        },
+        {
+          padId: "U1_2",
+          networkId: "SIG_B",
+          type: "rect",
+          offset: { x: 0.6, y: 0 },
+          size: { x: 1, y: 1 },
+        },
+      ],
+      courtyard: {
+        offsetFromCenter: { x: 0, y: 0 },
+        width: 8,
+        height: 4,
+      },
+    },
+    {
+      componentId: "U2",
+      pads: [
+        {
+          padId: "U2_1",
+          networkId: "SIG_A",
+          type: "rect",
+          offset: { x: 0.6, y: 0 },
+          size: { x: 1, y: 1 },
+        },
+        {
+          padId: "U2_2",
+          networkId: "SIG_B",
+          type: "rect",
+          offset: { x: -0.6, y: 0 },
+          size: { x: 1, y: 1 },
+        },
+      ],
+      courtyard: {
+        offsetFromCenter: { x: 0, y: 0 },
+        width: 8,
+        height: 4,
+      },
+    },
+  ],
+  minGap: 0.5,
+  packOrderStrategy: "largest_to_smallest",
+  packPlacementStrategy: "minimum_sum_squared_distance_to_network",
+}

--- a/tests/courtyard-packing.test.ts
+++ b/tests/courtyard-packing.test.ts
@@ -1,0 +1,226 @@
+import { test, expect } from "bun:test"
+import { convertCircuitJsonToPackOutput } from "../lib/plumbing/convertCircuitJsonToPackOutput"
+import { convertPackOutputToPackInput } from "../lib/plumbing/convertPackOutputToPackInput"
+import { checkOverlapWithPackedComponents } from "../lib/PackSolver2/checkOverlapWithPackedComponents"
+import { pack } from "../lib/pack"
+import type { PackOutput, PackedComponent } from "../lib/types"
+
+test("convertCircuitJsonToPackOutput extracts pcb_courtyard_rect", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      source_group_id: "root",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 0, y: 0 },
+      rotation: 0,
+      width: 2,
+      height: 2,
+      layer: "top",
+    },
+    {
+      type: "source_port",
+      source_port_id: "sp1",
+      source_component_id: "sc1",
+      name: "1",
+    },
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp1",
+      pcb_component_id: "pc1",
+      source_port_id: "sp1",
+      x: 0,
+      y: 0,
+      layers: ["top"],
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      pcb_component_id: "pc1",
+      pcb_port_id: "pp1",
+      shape: "rect",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      layer: "top",
+    },
+    {
+      type: "pcb_courtyard_rect",
+      pcb_courtyard_rect_id: "cy1",
+      pcb_component_id: "pc1",
+      center: { x: 0, y: 0 },
+      width: 4,
+      height: 3,
+      layer: "top",
+    },
+    {
+      type: "source_group",
+      source_group_id: "root",
+      name: "root",
+    },
+  ] as any
+
+  const result = convertCircuitJsonToPackOutput(circuitJson, {
+    source_group_id: "root",
+  })
+
+  const comp = result.components.find((c) => c.componentId === "pc1")
+  expect(comp).toBeDefined()
+  expect(comp!.courtyard).toEqual({
+    offsetFromCenter: { x: 0, y: 0 },
+    width: 4,
+    height: 3,
+  })
+})
+
+test("overlapping courtyards are detected even when pads don't overlap", () => {
+  // Two components with small pads (1x1) but large courtyards (6x4)
+  // Placed 4mm apart: pads have 3mm gap, but courtyards overlap by 2mm
+  const comp1: PackedComponent = {
+    componentId: "U1",
+    center: { x: 0, y: 0 },
+    ccwRotationOffset: 0,
+    pads: [
+      {
+        padId: "p1",
+        networkId: "net1",
+        type: "rect",
+        offset: { x: 0, y: 0 },
+        size: { x: 1, y: 1 },
+        absoluteCenter: { x: 0, y: 0 },
+      },
+    ],
+    courtyard: {
+      offsetFromCenter: { x: 0, y: 0 },
+      width: 6,
+      height: 4,
+    },
+  }
+
+  const comp2: PackedComponent = {
+    componentId: "U2",
+    center: { x: 4, y: 0 },
+    ccwRotationOffset: 0,
+    pads: [
+      {
+        padId: "p2",
+        networkId: "net2",
+        type: "rect",
+        offset: { x: 0, y: 0 },
+        size: { x: 1, y: 1 },
+        absoluteCenter: { x: 4, y: 0 },
+      },
+    ],
+    courtyard: {
+      offsetFromCenter: { x: 0, y: 0 },
+      width: 6,
+      height: 4,
+    },
+  }
+
+  const result = checkOverlapWithPackedComponents({
+    component: comp2,
+    packedComponents: [comp1],
+    minGap: 0.5,
+  })
+
+  expect(result.hasOverlap).toBe(true)
+})
+
+test("pack spaces courtyard components apart by courtyard size + minGap", () => {
+  const result = pack({
+    components: [
+      {
+        componentId: "U1",
+        pads: [
+          {
+            padId: "p1",
+            networkId: "net1",
+            type: "rect",
+            offset: { x: 0, y: 0 },
+            size: { x: 1, y: 1 },
+          },
+        ],
+        courtyard: {
+          offsetFromCenter: { x: 0, y: 0 },
+          width: 5,
+          height: 5,
+        },
+      },
+      {
+        componentId: "U2",
+        pads: [
+          {
+            padId: "p2",
+            networkId: "net1",
+            type: "rect",
+            offset: { x: 0, y: 0 },
+            size: { x: 1, y: 1 },
+          },
+        ],
+        courtyard: {
+          offsetFromCenter: { x: 0, y: 0 },
+          width: 5,
+          height: 5,
+        },
+      },
+    ],
+    minGap: 0.5,
+    packOrderStrategy: "largest_to_smallest",
+    packPlacementStrategy: "minimum_sum_squared_distance_to_network",
+  })
+
+  expect(result.components.length).toBe(2)
+
+  const c1 = result.components.find((c) => c.componentId === "U1")!
+  const c2 = result.components.find((c) => c.componentId === "U2")!
+  const dx = Math.abs(c1.center.x - c2.center.x)
+  const dy = Math.abs(c1.center.y - c2.center.y)
+
+  // Centers must be at least 5 (half courtyard + half courtyard) + 0.5 (minGap) apart
+  expect(Math.max(dx, dy)).toBeGreaterThanOrEqual(5.5 - 0.01)
+})
+
+test("convertPackOutputToPackInput preserves courtyard field", () => {
+  const packOutput: PackOutput = {
+    components: [
+      {
+        componentId: "U1",
+        center: { x: 0, y: 0 },
+        ccwRotationOffset: 0,
+        pads: [
+          {
+            padId: "p1",
+            networkId: "net1",
+            type: "rect",
+            offset: { x: 0, y: 0 },
+            size: { x: 1, y: 1 },
+            absoluteCenter: { x: 0, y: 0 },
+          },
+        ],
+        courtyard: {
+          offsetFromCenter: { x: 0.5, y: 0 },
+          width: 6,
+          height: 4,
+        },
+      },
+    ],
+    minGap: 1,
+    packOrderStrategy: "largest_to_smallest",
+    packPlacementStrategy: "minimum_sum_squared_distance_to_network",
+  }
+
+  const input = convertPackOutputToPackInput(packOutput)
+  expect(input.components[0]!.courtyard).toEqual({
+    offsetFromCenter: { x: 0.5, y: 0 },
+    width: 6,
+    height: 4,
+  })
+})


### PR DESCRIPTION
Adds support for PCB courtyards (pcb_courtyard_rect, pcb_courtyard_polygon, pcb_courtyard_outline) as component collision boundaries. When a component has courtyard data, the packer uses it instead of pad-based bounds for overlap detection, outline construction, and obstacle clearance — preventing component bodies from overlapping even when pads don't.