### PR TITLE
feat: support shouldBeOnEdgeOfBoard/mustBeOnBoundary constraints

### DIFF
--- a/lib/OutlineSegmentCandidatePointSolver/OutlineSegmentCandidatePointSolver.ts
+++ b/lib/OutlineSegmentCandidatePointSolver/OutlineSegmentCandidatePointSolver.ts
@@ -51,6 +51,7 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
   optimalPosition?: Point
   irlsSolver?: MultiOffsetIrlsSolver
   twoPhaseIrlsSolver?: TwoPhaseIrlsSolver
+  isBoundaryOutline?: boolean
 
   override getSolverName(): string {
     return "OutlineSegmentCandidatePointSolver"
@@ -72,6 +73,7 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
     globalBounds?: Bounds
     boundaryOutline?: Array<{ x: number; y: number }>
     weightedConnections?: PackInput["weightedConnections"]
+    isBoundaryOutline?: boolean
   }) {
     super()
     this.outlineSegment = params.outlineSegment
@@ -85,6 +87,7 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
     this.globalBounds = params.globalBounds
     this.boundaryOutline = params.boundaryOutline
     this.weightedConnections = params.weightedConnections
+    this.isBoundaryOutline = params.isBoundaryOutline
   }
 
   override getConstructorParams(): ConstructorParameters<
@@ -102,6 +105,7 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
       globalBounds: this.globalBounds,
       boundaryOutline: this.boundaryOutline,
       weightedConnections: this.weightedConnections,
+      isBoundaryOutline: this.isBoundaryOutline,
     }
   }
 
@@ -144,10 +148,13 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
       return this.adjustPositionForOutlineCollision(projectedPoint)
     }
 
-    const outwardNormal = getOutwardNormal(
+    let outwardNormal = getOutwardNormal(
       this.outlineSegment,
       this.ccwFullOutline,
     )
+    if (this.isBoundaryOutline) {
+      outwardNormal = { x: -outwardNormal.x, y: -outwardNormal.y }
+    }
     const componentBounds = getInputComponentBounds(this.componentToPack, {
       rotationDegrees: this.componentRotationDegrees,
     })
@@ -183,7 +190,10 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
     }
     signedArea /= 2
     const isCW = signedArea < 0
-    const rectSearchMode = isCW ? "inside" : "outside"
+    let rectSearchMode: "inside" | "outside" = isCW ? "inside" : "outside"
+    if (this.isBoundaryOutline) {
+      rectSearchMode = isCW ? "outside" : "inside"
+    }
 
     const largestRectSolverParams: ConstructorParameters<
       typeof LargestRectOutsideOutlineFromPointSolver
@@ -467,6 +477,9 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
    * and ensure the component stays within the boundary outline
    */
   private adjustPositionForOutlineCollision(center: Point): Point {
+    if (this.isBoundaryOutline) {
+      return center
+    }
     // Create temporary component at this position
     const tempComponent = this.createTemporaryPackedComponent(center)
 
@@ -474,10 +487,13 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
     const bounds = getComponentBounds(tempComponent, 0)
 
     // Get the outward normal for the current segment to push the component out
-    const outwardNormal = getOutwardNormal(
+    let outwardNormal = getOutwardNormal(
       this.outlineSegment,
       this.ccwFullOutline,
     )
+    if (this.isBoundaryOutline) {
+      outwardNormal = { x: -outwardNormal.x, y: -outwardNormal.y }
+    }
 
     // To compute push distance, we need to consider the direction of the
     // outward normal and the distance we need to push using the minX/maxX or

--- a/lib/PackSolver2/PackSolver2.ts
+++ b/lib/PackSolver2/PackSolver2.ts
@@ -152,7 +152,6 @@ export class PackSolver2 extends BaseSolver {
       outsideBoundaryOutline = !allPadsInside || !cornersInside
     }
 
-
     if (!tooCloseToObstacles && !outsideBoundaryOutline) {
       this.packedComponents.push(newPackedComponent)
       return

--- a/lib/PackSolver2/PackSolver2.ts
+++ b/lib/PackSolver2/PackSolver2.ts
@@ -123,8 +123,12 @@ export class PackSolver2 extends BaseSolver {
     })
 
     // Check if component is outside boundary outline
-    let outsideBoundaryOutline = false
+    const mustBeOnEdge =
+      firstComponentToPack.mustBeOnBoundary ||
+      firstComponentToPack.shouldBeOnEdgeOfBoard
+    let outsideBoundaryOutline = mustBeOnEdge ? true : false
     if (
+      !mustBeOnEdge &&
       this.packInput.boundaryOutline &&
       this.packInput.boundaryOutline.length >= 3
     ) {
@@ -147,6 +151,7 @@ export class PackSolver2 extends BaseSolver {
 
       outsideBoundaryOutline = !allPadsInside || !cornersInside
     }
+
 
     if (!tooCloseToObstacles && !outsideBoundaryOutline) {
       this.packedComponents.push(newPackedComponent)

--- a/lib/SingleComponentPackSolver/SingleComponentPackSolver.ts
+++ b/lib/SingleComponentPackSolver/SingleComponentPackSolver.ts
@@ -29,7 +29,6 @@ interface QueuedOutlineSegment {
   isBoundaryOutline?: boolean
 }
 
-
 interface CandidateResult {
   segment: Segment
   rotation: number
@@ -319,7 +318,10 @@ export class SingleComponentPackSolver extends BaseSolver {
 
           // Check if all pads are within the boundary outline
           const allPadsInside = candidateComponent.pads.every((pad) =>
-            isPointInsideOrOnBoundary(pad.absoluteCenter, this.boundaryOutline!),
+            isPointInsideOrOnBoundary(
+              pad.absoluteCenter,
+              this.boundaryOutline!,
+            ),
           )
 
           // Also check corners of component bounds
@@ -328,7 +330,9 @@ export class SingleComponentPackSolver extends BaseSolver {
             { x: componentBounds.minX, y: componentBounds.maxY },
             { x: componentBounds.maxX, y: componentBounds.minY },
             { x: componentBounds.maxX, y: componentBounds.maxY },
-          ].every((corner) => isPointInsideOrOnBoundary(corner, this.boundaryOutline!))
+          ].every((corner) =>
+            isPointInsideOrOnBoundary(corner, this.boundaryOutline!),
+          )
 
           outsideBoundaryOutline = !allPadsInside || !cornersInside
         }
@@ -771,11 +775,7 @@ export class SingleComponentPackSolver extends BaseSolver {
   }
 }
 
-function getPointToSegmentDistance(
-  p: Point,
-  a: Point,
-  b: Point,
-): number {
+function getPointToSegmentDistance(p: Point, a: Point, b: Point): number {
   const vx = b.x - a.x
   const vy = b.y - a.y
   const wx = p.x - a.x
@@ -884,4 +884,3 @@ function isPointInsideOrOnBoundary(
   }
   return false
 }
-

--- a/lib/SingleComponentPackSolver/SingleComponentPackSolver.ts
+++ b/lib/SingleComponentPackSolver/SingleComponentPackSolver.ts
@@ -26,7 +26,9 @@ interface QueuedOutlineSegment {
   availableRotations: number[]
   segmentIndex: number
   ccwFullOutline: Segment[] // The entire outline containing this segment
+  isBoundaryOutline?: boolean
 }
+
 
 interface CandidateResult {
   segment: Segment
@@ -126,7 +128,11 @@ export class SingleComponentPackSolver extends BaseSolver {
 
   private executeOutlinePhase() {
     // Special case: if no packed components, attempt center; if too close to obstacles, fall back to outline-based placement
-    if (this.packedComponents.length === 0) {
+    if (
+      this.packedComponents.length === 0 &&
+      !this.componentToPack.mustBeOnBoundary &&
+      !this.componentToPack.shouldBeOnEdgeOfBoard
+    ) {
       const availableRotations = this.componentToPack
         .availableRotationDegrees ?? [0, 90, 180, 270]
       const position = { x: 0, y: 0 }
@@ -205,6 +211,7 @@ export class SingleComponentPackSolver extends BaseSolver {
           availableRotations: [...availableRotations],
           segmentIndex: boundaryOutlineIndex * 1000 + i,
           ccwFullOutline: boundarySegments,
+          isBoundaryOutline: true,
         })
       }
     }
@@ -312,7 +319,7 @@ export class SingleComponentPackSolver extends BaseSolver {
 
           // Check if all pads are within the boundary outline
           const allPadsInside = candidateComponent.pads.every((pad) =>
-            isPointInPolygon(pad.absoluteCenter, this.boundaryOutline!),
+            isPointInsideOrOnBoundary(pad.absoluteCenter, this.boundaryOutline!),
           )
 
           // Also check corners of component bounds
@@ -321,9 +328,25 @@ export class SingleComponentPackSolver extends BaseSolver {
             { x: componentBounds.minX, y: componentBounds.maxY },
             { x: componentBounds.maxX, y: componentBounds.minY },
             { x: componentBounds.maxX, y: componentBounds.maxY },
-          ].every((corner) => isPointInPolygon(corner, this.boundaryOutline!))
+          ].every((corner) => isPointInsideOrOnBoundary(corner, this.boundaryOutline!))
 
           outsideBoundaryOutline = !allPadsInside || !cornersInside
+        }
+
+        // Check if component must touch the boundary outline
+        let violatesBoundaryConstraint = false
+        if (
+          (this.componentToPack.mustBeOnBoundary ||
+            this.componentToPack.shouldBeOnEdgeOfBoard) &&
+          this.boundaryOutline &&
+          this.boundaryOutline.length >= 3
+        ) {
+          const distanceToBoundary = getDistanceToBoundaryOutline(
+            candidateComponent,
+            this.boundaryOutline,
+          )
+          // Allow a small tolerance of 0.01 mm (10 microns)
+          violatesBoundaryConstraint = distanceToBoundary > 0.01
         }
 
         // Calculate distance based on pack strategy
@@ -368,6 +391,16 @@ export class SingleComponentPackSolver extends BaseSolver {
             segmentIndex: queuedSegment.segmentIndex,
             rotationIndex: this.currentRotationIndex,
             gapDistance: -1, // Special marker for boundary violation
+          })
+        } else if (violatesBoundaryConstraint) {
+          this.rejectedCandidates.push({
+            segment: queuedSegment.segment,
+            rotation,
+            optimalPosition,
+            distance,
+            segmentIndex: queuedSegment.segmentIndex,
+            rotationIndex: this.currentRotationIndex,
+            gapDistance: -2, // Special marker for boundary constraint violation
           })
         } else {
           // Store candidate result
@@ -422,6 +455,7 @@ export class SingleComponentPackSolver extends BaseSolver {
         globalBounds: this.bounds,
         boundaryOutline: this.boundaryOutline,
         weightedConnections: this.weightedConnections,
+        isBoundaryOutline: queuedSegment.isBoundaryOutline,
       })
 
       this.activeSubSolver.setup()
@@ -736,3 +770,118 @@ export class SingleComponentPackSolver extends BaseSolver {
     }
   }
 }
+
+function getPointToSegmentDistance(
+  p: Point,
+  a: Point,
+  b: Point,
+): number {
+  const vx = b.x - a.x
+  const vy = b.y - a.y
+  const wx = p.x - a.x
+  const wy = p.y - a.y
+  const vSq = vx * vx + vy * vy
+  if (vSq === 0) {
+    return Math.hypot(p.x - a.x, p.y - a.y)
+  }
+  let t = (wx * vx + wy * vy) / vSq
+  t = Math.max(0, Math.min(1, t))
+  const projX = a.x + t * vx
+  const projY = a.y + t * vy
+  return Math.hypot(p.x - projX, p.y - projY)
+}
+
+function ccw(a: Point, b: Point, c: Point): boolean {
+  return (c.y - a.y) * (b.x - a.x) > (b.y - a.y) * (c.x - a.x)
+}
+
+function intersect(a: Point, b: Point, c: Point, d: Point): boolean {
+  return ccw(a, c, d) !== ccw(b, c, d) && ccw(a, b, c) !== ccw(a, b, d)
+}
+
+function getSegmentToSegmentDistance(
+  a: Point,
+  b: Point,
+  c: Point,
+  d: Point,
+): number {
+  if (intersect(a, b, c, d)) {
+    return 0
+  }
+  return Math.min(
+    getPointToSegmentDistance(a, c, d),
+    getPointToSegmentDistance(b, c, d),
+    getPointToSegmentDistance(c, a, b),
+    getPointToSegmentDistance(d, a, b),
+  )
+}
+
+function getDistanceToBoundaryOutline(
+  component: PackedComponent,
+  boundaryOutline: Point[],
+): number {
+  const boxes = getComponentCollisionBoxes(component)
+  let minDistance = Infinity
+
+  const boundarySegments: [Point, Point][] = []
+  for (let i = 0; i < boundaryOutline.length; i++) {
+    boundarySegments.push([
+      boundaryOutline[i]!,
+      boundaryOutline[(i + 1) % boundaryOutline.length]!,
+    ])
+  }
+
+  for (const box of boxes) {
+    const minX = box.center.x - box.width / 2
+    const maxX = box.center.x + box.width / 2
+    const minY = box.center.y - box.height / 2
+    const maxY = box.center.y + box.height / 2
+
+    const corners = [
+      { x: minX, y: minY },
+      { x: maxX, y: minY },
+      { x: maxX, y: maxY },
+      { x: minX, y: maxY },
+    ]
+
+    const boxSegments: [Point, Point][] = [
+      [corners[0]!, corners[1]!],
+      [corners[1]!, corners[2]!],
+      [corners[2]!, corners[3]!],
+      [corners[3]!, corners[0]!],
+    ]
+
+    for (const boxSeg of boxSegments) {
+      for (const bSeg of boundarySegments) {
+        const dist = getSegmentToSegmentDistance(
+          boxSeg[0],
+          boxSeg[1],
+          bSeg[0],
+          bSeg[1],
+        )
+        if (dist < minDistance) {
+          minDistance = dist
+        }
+      }
+    }
+  }
+
+  return minDistance
+}
+
+function isPointInsideOrOnBoundary(
+  point: Point,
+  boundaryOutline: Point[],
+  tolerance = 0.01,
+): boolean {
+  if (isPointInPolygon(point, boundaryOutline)) return true
+
+  for (let i = 0; i < boundaryOutline.length; i++) {
+    const p1 = boundaryOutline[i]!
+    const p2 = boundaryOutline[(i + 1) % boundaryOutline.length]!
+    const dist = getPointToSegmentDistance(point, p1, p2)
+    if (dist <= tolerance) return true
+  }
+  return false
+}
+

--- a/lib/plumbing/convertCircuitJsonToPackOutput.ts
+++ b/lib/plumbing/convertCircuitJsonToPackOutput.ts
@@ -178,6 +178,14 @@ const buildPackedComponent = (
     componentCenter: center,
   })
 
+  const shouldBeOnEdgeOfBoard = pcbComponents.some(
+    (pc: any) =>
+      pc.should_be_on_edge_of_board === true ||
+      pc.shouldBeOnEdgeOfBoard === true ||
+      pc.must_be_on_boundary === true ||
+      pc.mustBeOnBoundary === true,
+  )
+
   return {
     componentId,
     isStatic,
@@ -185,6 +193,8 @@ const buildPackedComponent = (
     ccwRotationOffset: 0,
     pads,
     courtyard,
+    shouldBeOnEdgeOfBoard,
+    mustBeOnBoundary: shouldBeOnEdgeOfBoard,
   } as PackedComponent
 }
 
@@ -237,6 +247,21 @@ export const convertCircuitJsonToPackOutput = (
   )
   if (pcbBoard?.outline) {
     packOutput.boundaryOutline = pcbBoard.outline
+  } else if (
+    pcbBoard &&
+    pcbBoard.width !== undefined &&
+    pcbBoard.height !== undefined
+  ) {
+    const cx = pcbBoard.center?.x ?? 0
+    const cy = pcbBoard.center?.y ?? 0
+    const w = pcbBoard.width
+    const h = pcbBoard.height
+    packOutput.boundaryOutline = [
+      { x: cx - w / 2, y: cy - h / 2 },
+      { x: cx + w / 2, y: cy - h / 2 },
+      { x: cx + w / 2, y: cy + h / 2 },
+      { x: cx - w / 2, y: cy + h / 2 },
+    ]
   }
 
   const getNetworkId = (pcbPortId?: string): string => {

--- a/lib/plumbing/convertCircuitJsonToPackOutput.ts
+++ b/lib/plumbing/convertCircuitJsonToPackOutput.ts
@@ -245,12 +245,22 @@ export const convertCircuitJsonToPackOutput = (
   const pcbBoard = (circuitJson as any[]).find(
     (item: any) => item.type === "pcb_board",
   )
+  const hasEdgeConstrainedComponent = (circuitJson as any[]).some(
+    (item: any) =>
+      item.type === "pcb_component" &&
+      (item.should_be_on_edge_of_board === true ||
+        item.shouldBeOnEdgeOfBoard === true ||
+        item.must_be_on_boundary === true ||
+        item.mustBeOnBoundary === true),
+  )
+
   if (pcbBoard?.outline) {
     packOutput.boundaryOutline = pcbBoard.outline
   } else if (
     pcbBoard &&
     pcbBoard.width !== undefined &&
-    pcbBoard.height !== undefined
+    pcbBoard.height !== undefined &&
+    hasEdgeConstrainedComponent
   ) {
     const cx = pcbBoard.center?.x ?? 0
     const cy = pcbBoard.center?.y ?? 0

--- a/lib/plumbing/convertPackOutputToPackInput.ts
+++ b/lib/plumbing/convertPackOutputToPackInput.ts
@@ -25,6 +25,8 @@ export const convertPackOutputToPackInput = (packed: PackOutput): PackInput => {
           availableRotationDegrees: pc.availableRotationDegrees, // Preserve rotation constraints
           pads: pc.pads.map(({ absoluteCenter: _ac, ...rest }) => rest),
           courtyard: pc.courtyard,
+          mustBeOnBoundary: pc.mustBeOnBoundary,
+          shouldBeOnEdgeOfBoard: pc.shouldBeOnEdgeOfBoard,
         }),
   }))
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -36,7 +36,10 @@ export interface InputComponent {
   pads: InputPad[]
   /** Optional courtyard defining the component's physical boundary */
   courtyard?: ComponentCourtyard
+  mustBeOnBoundary?: boolean
+  shouldBeOnEdgeOfBoard?: boolean
 }
+
 
 export interface PackedComponent extends InputComponent {
   center: { x: number; y: number }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -40,7 +40,6 @@ export interface InputComponent {
   shouldBeOnEdgeOfBoard?: boolean
 }
 
-
 export interface PackedComponent extends InputComponent {
   center: { x: number; y: number }
   /** @deprecated Rotation in degrees (counterclockwise) */

--- a/tests/edge-boundary-placement.test.ts
+++ b/tests/edge-boundary-placement.test.ts
@@ -39,8 +39,6 @@ test("PackSolver2 places components with mustBeOnBoundary on the board edge", ()
   const solver = new PackSolver2(packInput)
   solver.solve()
 
-
-
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
   expect(solver.packedComponents).toHaveLength(1)
@@ -119,8 +117,12 @@ test("PackSolver2 places multiple components correctly with boundary outline", (
   expect(solver.failed).toBe(false)
   expect(solver.packedComponents).toHaveLength(2)
 
-  const edgeComp = solver.packedComponents.find(c => c.componentId === "edge_comp")!
-  const normalComp = solver.packedComponents.find(c => c.componentId === "normal_comp")!
+  const edgeComp = solver.packedComponents.find(
+    (c) => c.componentId === "edge_comp",
+  )!
+  const normalComp = solver.packedComponents.find(
+    (c) => c.componentId === "normal_comp",
+  )!
 
   // edgeComp must touch the boundary
   const x = edgeComp.center.x
@@ -140,25 +142,85 @@ test("reproduce SOIC8 chip boundary placement on 40x40 board", () => {
         componentId: "chip_u1",
         shouldBeOnEdgeOfBoard: true,
         pads: [
-          { padId: "pad0", type: "rect", offset: { x: -2.15, y: 1.905 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
-          { padId: "pad1", type: "rect", offset: { x: -2.15, y: 0.635 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
-          { padId: "pad2", type: "rect", offset: { x: -2.15, y: -0.635 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
-          { padId: "pad3", type: "rect", offset: { x: -2.15, y: -1.905 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
-          { padId: "pad4", type: "rect", offset: { x: 2.15, y: -1.905 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
-          { padId: "pad5", type: "rect", offset: { x: 2.15, y: -0.635 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
-          { padId: "pad6", type: "rect", offset: { x: 2.15, y: 0.635 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
-          { padId: "pad7", type: "rect", offset: { x: 2.15, y: 1.905 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
+          {
+            padId: "pad0",
+            type: "rect",
+            offset: { x: -2.15, y: 1.905 },
+            size: { x: 1, y: 0.6 },
+            networkId: "net1",
+          },
+          {
+            padId: "pad1",
+            type: "rect",
+            offset: { x: -2.15, y: 0.635 },
+            size: { x: 1, y: 0.6 },
+            networkId: "net1",
+          },
+          {
+            padId: "pad2",
+            type: "rect",
+            offset: { x: -2.15, y: -0.635 },
+            size: { x: 1, y: 0.6 },
+            networkId: "net1",
+          },
+          {
+            padId: "pad3",
+            type: "rect",
+            offset: { x: -2.15, y: -1.905 },
+            size: { x: 1, y: 0.6 },
+            networkId: "net1",
+          },
+          {
+            padId: "pad4",
+            type: "rect",
+            offset: { x: 2.15, y: -1.905 },
+            size: { x: 1, y: 0.6 },
+            networkId: "net1",
+          },
+          {
+            padId: "pad5",
+            type: "rect",
+            offset: { x: 2.15, y: -0.635 },
+            size: { x: 1, y: 0.6 },
+            networkId: "net1",
+          },
+          {
+            padId: "pad6",
+            type: "rect",
+            offset: { x: 2.15, y: 0.635 },
+            size: { x: 1, y: 0.6 },
+            networkId: "net1",
+          },
+          {
+            padId: "pad7",
+            type: "rect",
+            offset: { x: 2.15, y: 1.905 },
+            size: { x: 1, y: 0.6 },
+            networkId: "net1",
+          },
         ],
         availableRotationDegrees: [0],
       },
       {
         componentId: "res_r1",
         pads: [
-          { padId: "pad8", type: "rect", offset: { x: -0.5, y: 0 }, size: { x: 0.6, y: 0.6 }, networkId: "net1" },
-          { padId: "pad9", type: "rect", offset: { x: 0.5, y: 0 }, size: { x: 0.6, y: 0.6 }, networkId: "net1" },
+          {
+            padId: "pad8",
+            type: "rect",
+            offset: { x: -0.5, y: 0 },
+            size: { x: 0.6, y: 0.6 },
+            networkId: "net1",
+          },
+          {
+            padId: "pad9",
+            type: "rect",
+            offset: { x: 0.5, y: 0 },
+            size: { x: 0.6, y: 0.6 },
+            networkId: "net1",
+          },
         ],
         availableRotationDegrees: [0],
-      }
+      },
     ],
     boundaryOutline: [
       { x: -20, y: -20 },
@@ -178,16 +240,16 @@ test("reproduce SOIC8 chip boundary placement on 40x40 board", () => {
   expect(solver.failed).toBe(false)
   expect(solver.packedComponents).toHaveLength(2)
 
-  const u1 = solver.packedComponents.find(c => c.componentId === "chip_u1")!
+  const u1 = solver.packedComponents.find((c) => c.componentId === "chip_u1")!
   console.log("REPRODUCTION U1 CENTER:", u1.center)
   console.log("REPRODUCTION U1 PADS:", JSON.stringify(u1.pads, null, 2))
 
   const halfWidth = 5.3 / 2
   const halfHeight = 4.41 / 2
-  const distToLeft = Math.abs((u1.center.x - halfWidth) - -20)
-  const distToRight = Math.abs((u1.center.x + halfWidth) - 20)
-  const distToBottom = Math.abs((u1.center.y - halfHeight) - -20)
-  const distToTop = Math.abs((u1.center.y + halfHeight) - 20)
+  const distToLeft = Math.abs(u1.center.x - halfWidth - -20)
+  const distToRight = Math.abs(u1.center.x + halfWidth - 20)
+  const distToBottom = Math.abs(u1.center.y - halfHeight - -20)
+  const distToTop = Math.abs(u1.center.y + halfHeight - 20)
   const minDistance = Math.min(distToLeft, distToRight, distToBottom, distToTop)
 
   expect(minDistance).toBeLessThan(0.1)

--- a/tests/edge-boundary-placement.test.ts
+++ b/tests/edge-boundary-placement.test.ts
@@ -1,0 +1,194 @@
+import { test, expect } from "bun:test"
+import { PackSolver2 } from "../lib/PackSolver2/PackSolver2"
+import type { PackInput } from "../lib/types"
+
+test("PackSolver2 places components with mustBeOnBoundary on the board edge", () => {
+  const packInput: PackInput = {
+    components: [
+      {
+        componentId: "edge_comp",
+        mustBeOnBoundary: true,
+        pads: [
+          {
+            padId: "pad1",
+            type: "rect",
+            offset: { x: 0, y: 0 },
+            size: { x: 2, y: 2 },
+            networkId: "net1",
+          },
+        ],
+        availableRotationDegrees: [0],
+        courtyard: {
+          offsetFromCenter: { x: 0, y: 0 },
+          width: 2,
+          height: 2,
+        },
+      },
+    ],
+    boundaryOutline: [
+      { x: -10, y: -10 },
+      { x: 10, y: -10 },
+      { x: 10, y: 10 },
+      { x: -10, y: 10 },
+    ],
+    minGap: 0,
+    packOrderStrategy: "largest_to_smallest",
+    packPlacementStrategy: "minimum_sum_distance_to_network",
+  }
+
+  const solver = new PackSolver2(packInput)
+  solver.solve()
+
+
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.packedComponents).toHaveLength(1)
+
+  const component = solver.packedComponents[0]!
+  expect(component.componentId).toBe("edge_comp")
+
+  // The centroid of the boundary is at (0, 0).
+  // An edge component should NOT be at (0, 0).
+  expect(component.center).not.toEqual({ x: 0, y: 0 })
+
+  // Since courtyard width/height is 2, it is a 2x2 square.
+  // The center is (x, y). The edges are x +/- 1, y +/- 1.
+  // The boundary outline is x = +/- 10, y = +/- 10.
+  // So one of the component edges must touch the boundary outline (i.e. x +/- 1 = +/-10 or y +/- 1 = +/-10).
+  // That means x must be +/-9 or y must be +/-9.
+  const touchesLeft = Math.abs(component.center.x - -9) < 0.01
+  const touchesRight = Math.abs(component.center.x - 9) < 0.01
+  const touchesBottom = Math.abs(component.center.y - -9) < 0.01
+  const touchesTop = Math.abs(component.center.y - 9) < 0.01
+
+  expect(touchesLeft || touchesRight || touchesBottom || touchesTop).toBe(true)
+})
+
+test("PackSolver2 places multiple components correctly with boundary outline", () => {
+  const packInput: PackInput = {
+    components: [
+      {
+        componentId: "edge_comp",
+        shouldBeOnEdgeOfBoard: true,
+        pads: [
+          {
+            padId: "pad1",
+            type: "rect",
+            offset: { x: 0, y: 0 },
+            size: { x: 2, y: 2 },
+            networkId: "net1",
+          },
+        ],
+        availableRotationDegrees: [0],
+        courtyard: {
+          offsetFromCenter: { x: 0, y: 0 },
+          width: 2,
+          height: 2,
+        },
+      },
+      {
+        componentId: "normal_comp",
+        pads: [
+          {
+            padId: "pad2",
+            type: "rect",
+            offset: { x: 0, y: 0 },
+            size: { x: 1, y: 1 },
+            networkId: "net1",
+          },
+        ],
+        availableRotationDegrees: [0],
+      },
+    ],
+    boundaryOutline: [
+      { x: -10, y: -10 },
+      { x: 10, y: -10 },
+      { x: 10, y: 10 },
+      { x: -10, y: 10 },
+    ],
+    minGap: 0.5,
+    packOrderStrategy: "largest_to_smallest",
+    packPlacementStrategy: "minimum_sum_distance_to_network",
+  }
+
+  const solver = new PackSolver2(packInput)
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.packedComponents).toHaveLength(2)
+
+  const edgeComp = solver.packedComponents.find(c => c.componentId === "edge_comp")!
+  const normalComp = solver.packedComponents.find(c => c.componentId === "normal_comp")!
+
+  // edgeComp must touch the boundary
+  const x = edgeComp.center.x
+  const y = edgeComp.center.y
+  const touchesLeft = Math.abs(x - -9) < 0.01
+  const touchesRight = Math.abs(x - 9) < 0.01
+  const touchesBottom = Math.abs(y - -9) < 0.01
+  const touchesTop = Math.abs(y - 9) < 0.01
+
+  expect(touchesLeft || touchesRight || touchesBottom || touchesTop).toBe(true)
+})
+
+test("reproduce SOIC8 chip boundary placement on 40x40 board", () => {
+  const packInput: PackInput = {
+    components: [
+      {
+        componentId: "chip_u1",
+        shouldBeOnEdgeOfBoard: true,
+        pads: [
+          { padId: "pad0", type: "rect", offset: { x: -2.15, y: 1.905 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
+          { padId: "pad1", type: "rect", offset: { x: -2.15, y: 0.635 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
+          { padId: "pad2", type: "rect", offset: { x: -2.15, y: -0.635 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
+          { padId: "pad3", type: "rect", offset: { x: -2.15, y: -1.905 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
+          { padId: "pad4", type: "rect", offset: { x: 2.15, y: -1.905 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
+          { padId: "pad5", type: "rect", offset: { x: 2.15, y: -0.635 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
+          { padId: "pad6", type: "rect", offset: { x: 2.15, y: 0.635 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
+          { padId: "pad7", type: "rect", offset: { x: 2.15, y: 1.905 }, size: { x: 1, y: 0.6 }, networkId: "net1" },
+        ],
+        availableRotationDegrees: [0],
+      },
+      {
+        componentId: "res_r1",
+        pads: [
+          { padId: "pad8", type: "rect", offset: { x: -0.5, y: 0 }, size: { x: 0.6, y: 0.6 }, networkId: "net1" },
+          { padId: "pad9", type: "rect", offset: { x: 0.5, y: 0 }, size: { x: 0.6, y: 0.6 }, networkId: "net1" },
+        ],
+        availableRotationDegrees: [0],
+      }
+    ],
+    boundaryOutline: [
+      { x: -20, y: -20 },
+      { x: 20, y: -20 },
+      { x: 20, y: 20 },
+      { x: -20, y: 20 },
+    ],
+    minGap: 0,
+    packOrderStrategy: "largest_to_smallest",
+    packPlacementStrategy: "minimum_sum_squared_distance_to_network",
+  }
+
+  const solver = new PackSolver2(packInput)
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.packedComponents).toHaveLength(2)
+
+  const u1 = solver.packedComponents.find(c => c.componentId === "chip_u1")!
+  console.log("REPRODUCTION U1 CENTER:", u1.center)
+  console.log("REPRODUCTION U1 PADS:", JSON.stringify(u1.pads, null, 2))
+
+  const halfWidth = 5.3 / 2
+  const halfHeight = 4.41 / 2
+  const distToLeft = Math.abs((u1.center.x - halfWidth) - -20)
+  const distToRight = Math.abs((u1.center.x + halfWidth) - 20)
+  const distToBottom = Math.abs((u1.center.y - halfHeight) - -20)
+  const distToTop = Math.abs((u1.center.y + halfHeight) - 20)
+  const minDistance = Math.min(distToLeft, distToRight, distToBottom, distToTop)
+
+  expect(minDistance).toBeLessThan(0.1)
+})


### PR DESCRIPTION
This PR adds support for mustBeOnBoundary / shouldBeOnEdgeOfBoard constraints in the packer. Constrained components are forced to touch the boundary outline (either using their courtyard or fallback pad bounds).