### PR TITLE
Fix PackSolver2 initial rotation handling

### DIFF
--- a/lib/PackSolver2/PackSolver2.ts
+++ b/lib/PackSolver2/PackSolver2.ts
@@ -64,7 +64,10 @@ export class PackSolver2 extends BaseSolver {
       const packedComponent: PackedComponent = {
         ...component,
         center: component.center ?? { x: 0, y: 0 },
-        ccwRotationOffset: component.ccwRotationOffset ?? 0,
+        ccwRotationOffset:
+          component.ccwRotationOffset ??
+          component.availableRotationDegrees?.[0] ??
+          0,
         pads: component.pads.map((pad) => ({
           ...pad,
           absoluteCenter: pad.absoluteCenter ?? { x: 0, y: 0 },
@@ -98,7 +101,10 @@ export class PackSolver2 extends BaseSolver {
     const newPackedComponent: PackedComponent = {
       ...firstComponentToPack,
       center: initialPosition,
-      ccwRotationOffset: 0,
+      ccwRotationOffset:
+        firstComponentToPack.ccwRotationOffset ??
+        firstComponentToPack.availableRotationDegrees?.[0] ??
+        0,
       pads: firstComponentToPack.pads.map((p) => ({
         ...p,
         absoluteCenter: { x: 0, y: 0 },
@@ -231,7 +237,10 @@ export class PackSolver2 extends BaseSolver {
         const packedComponent: PackedComponent = {
           ...this.componentToPack!,
           center: { x: 0, y: 0 },
-          ccwRotationOffset: 0,
+          ccwRotationOffset:
+            this.componentToPack?.ccwRotationOffset ??
+            this.componentToPack?.availableRotationDegrees?.[0] ??
+            0,
           pads: this.componentToPack!.pads.map((p) => ({
             ...p,
             absoluteCenter: { x: 0, y: 0 },

--- a/tests/pack-solver2-rotation-offsets.test.ts
+++ b/tests/pack-solver2-rotation-offsets.test.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "bun:test"
+import { PackSolver2 } from "../lib/PackSolver2/PackSolver2"
+import type { InputComponent, PackInput } from "../lib/types"
+
+const createComponent = (
+  componentId: string,
+  overrides: Partial<InputComponent> = {},
+): InputComponent => ({
+  componentId,
+  pads: [
+    {
+      padId: `${componentId}.pad1`,
+      type: "rect",
+      offset: { x: 0, y: 0 },
+      size: { x: 1, y: 1 },
+      networkId: `${componentId}.net1`,
+    },
+  ],
+  ...overrides,
+})
+
+const createPackInput = (component: InputComponent): PackInput => ({
+  components: [component],
+  minGap: 0.1,
+  packOrderStrategy: "largest_to_smallest",
+  packPlacementStrategy: "minimum_sum_distance_to_network",
+})
+
+test("PackSolver2 uses first available rotation for the first dynamic component", () => {
+  const solver = new PackSolver2(
+    createPackInput(
+      createComponent("comp1", {
+        availableRotationDegrees: [270],
+      }),
+    ),
+  )
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.packedComponents[0]?.ccwRotationOffset).toBe(270)
+})
+
+test("PackSolver2 uses first available rotation for static components", () => {
+  const solver = new PackSolver2(
+    createPackInput(
+      createComponent("comp1", {
+        isStatic: true,
+        center: { x: 2, y: 3 },
+        availableRotationDegrees: [90],
+      }),
+    ),
+  )
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.packedComponents[0]?.ccwRotationOffset).toBe(90)
+})
+
+test("PackSolver2 preserves explicit static rotation over available rotations", () => {
+  const solver = new PackSolver2(
+    createPackInput(
+      createComponent("comp1", {
+        isStatic: true,
+        center: { x: 2, y: 3 },
+        availableRotationDegrees: [90],
+        ccwRotationOffset: 180,
+      }),
+    ),
+  )
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.packedComponents[0]?.ccwRotationOffset).toBe(180)
+})


### PR DESCRIPTION
- Make `PackSolver2` honor `availableRotationDegrees[0]` when it directly creates packed components
- Preserve explicit `ccwRotationOffset` precedence for static components
- Add regression tests for first dynamic component rotation and static component rotation

**Why**
`SingleComponentPackSolver` already respected `availableRotationDegrees`, but `PackSolver2` had direct construction paths that defaulted rotation to `0`. That could make callers pass a single allowed rotation while the packed output still reported `0`.