### PR TITLE
fix: declare runtime dependencies (@flatten-js/core, math-utils, solver-utils)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
   "files": [
     "dist"
   ],
+  "dependencies": {
+    "@flatten-js/core": "^1.6.2"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.1.1",
-    "@flatten-js/core": "^1.6.2",
     "@react-hook/resize-observer": "^2.0.2",
     "@tscircuit/circuit-json-util": "^0.0.94",
     "@tscircuit/footprinter": "^0.0.203",
@@ -42,6 +44,8 @@
   },
   "peerDependencies": {
     "typescript": "^5",
-    "@tscircuit/circuit-json-util": "*"
+    "@tscircuit/circuit-json-util": "*",
+    "@tscircuit/math-utils": "*",
+    "@tscircuit/solver-utils": "*"
   }
 }


### PR DESCRIPTION
## Problem

A clean install can't import the package:

```bash
mkdir t && cd t && bun init -y
bun add calculate-packing
echo 'import * as m from "calculate-packing"' > s.ts && bun s.ts
# error: Cannot find module '@flatten-js/core'
```

Build is `tsup-node` (no bundling — imports stay external), but three packages the shipped `dist` imports were declared only in `devDependencies`, so consumers never received them. Real runtime imports in `lib/`: `@tscircuit/math-utils` ×21, `@tscircuit/solver-utils` ×4, `@flatten-js/core` ×3.

## Fix

Following this repo's `dependency-check` (`internal_lib`): external packages go in `dependencies`, internal `@tscircuit/*` in `peerDependencies` (`"*"`).

- `@flatten-js/core` → `dependencies`
- `@tscircuit/math-utils`, `@tscircuit/solver-utils` → `peerDependencies` (`"*"`), kept pinned in `devDependencies`

`bunx @tscircuit/dependency-check` passes; format-check / test / type-check green.

## Verification

Built, packed, installed the tarball in a clean project — `@flatten-js/core` resolves and the internal peers auto-install. (A full end-to-end import also needs the `circuit-json@0.0.443` root fix, tscircuit/circuit-json#633, which ships the same defect.)

Same class as tscircuit/dsn-converter#514, tscircuit/matchpack#150, tscircuit/checks#164.
