### PR TITLE
Add a repro test for getComponentBounds double-rotating 90/270 rect pad bounds

### DIFF
--- a/lib/geometry/getComponentBounds.test.ts
+++ b/lib/geometry/getComponentBounds.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import { getComponentBounds } from "./getComponentBounds"
+import { setPackedComponentPadCenters } from "../PackSolver2/setPackedComponentPadCenters"
+import type { PackedComponent } from "../types"
+
+// A 2x1 pad at the origin; rotating the component 90deg makes it 1 wide x 2 tall
+// in the world. setPackedComponentPadCenters swaps the pad size to match, but
+// getComponentBounds then rotates the already-swapped rect again, so the bounds
+// come out transposed (2 wide x 1 tall).
+test.failing("getComponentBounds handles a 90deg-rotated rect pad", () => {
+  const component: PackedComponent = {
+    componentId: "C1",
+    center: { x: 0, y: 0 },
+    ccwRotationOffset: 90,
+    pads: [
+      {
+        padId: "p1",
+        networkId: "n1",
+        type: "rect",
+        offset: { x: 0, y: 0 },
+        size: { x: 2, y: 1 },
+        absoluteCenter: { x: 0, y: 0 },
+      },
+    ],
+  }
+  setPackedComponentPadCenters(component)
+
+  const bounds = getComponentBounds(component, 0)
+  expect(bounds.maxX - bounds.minX).toBeCloseTo(1)
+  expect(bounds.maxY - bounds.minY).toBeCloseTo(2)
+})


### PR DESCRIPTION
`setPackedComponentPadCenters` already swaps a pad's width/height for 90°/270° rotations, but `getComponentBounds` then rotates that same rect again — so a 2×1 pad ends up 2×1 instead of 1×2, and packing sees the wrong bounds. This adds a failing test; fix to follow.