### PR TITLE
Assert exact bounds in the rotated rect pad test

### DIFF
--- a/lib/geometry/getComponentBounds.test.ts
+++ b/lib/geometry/getComponentBounds.test.ts
@@ -28,4 +28,8 @@ test("getComponentBounds handles a 90deg-rotated rect pad", () => {
   const bounds = getComponentBounds(component, 0)
   expect(bounds.maxX - bounds.minX).toBeCloseTo(1)
   expect(bounds.maxY - bounds.minY).toBeCloseTo(2)
+  expect(bounds.minX).toBeCloseTo(-0.5)
+  expect(bounds.maxX).toBeCloseTo(0.5)
+  expect(bounds.minY).toBeCloseTo(-1)
+  expect(bounds.maxY).toBeCloseTo(1)
 })


### PR DESCRIPTION
Applies @imrishabh18's review suggestion from #102 — assert the absolute min/max values, not just the spans.