### PR TITLE
Fix packing obstacle generation for pill-shaped SMT pads

### DIFF
--- a/lib/plumbing/extractPadInfos.ts
+++ b/lib/plumbing/extractPadInfos.ts
@@ -154,6 +154,17 @@ export const extractPadInfos = (
         })
         break
       }
+      case "pill": {
+        pushPad({
+          padId: sp.pcb_smtpad_id,
+          pcbPortId: sp.pcb_port_id,
+          sx: sp.width,
+          sy: sp.height,
+          x: sp.x,
+          y: sp.y,
+        })
+        break
+      }
       case "circle": {
         pushPad({
           padId: sp.pcb_smtpad_id,

--- a/tests/extractPadInfos-pill.test.ts
+++ b/tests/extractPadInfos-pill.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "bun:test"
+import { cju } from "@tscircuit/circuit-json-util"
+import type { CircuitJson, PcbComponent } from "circuit-json"
+import { convertCircuitJsonToPackOutput } from "../lib/plumbing/convertCircuitJsonToPackOutput"
+import { extractPadInfos } from "../lib/plumbing/extractPadInfos"
+
+const pillPadCircuitJson = [
+  {
+    type: "source_group",
+    source_group_id: "source_group_0",
+    is_subcircuit: true,
+    subcircuit_id: "subcircuit_source_group_0",
+  },
+  {
+    type: "source_component",
+    source_component_id: "source_component_0",
+    ftype: "simple_chip",
+    name: "U1",
+    source_group_id: "source_group_0",
+  },
+  {
+    type: "source_port",
+    source_port_id: "source_port_0",
+    name: "pin1",
+    pin_number: 1,
+    port_hints: ["pin1", "1"],
+    source_component_id: "source_component_0",
+    subcircuit_id: "subcircuit_source_group_0",
+  },
+  {
+    type: "pcb_component",
+    pcb_component_id: "pcb_component_0",
+    source_component_id: "source_component_0",
+    center: { x: 1, y: 2 },
+    width: 0.36,
+    height: 1.74,
+    layer: "top",
+    rotation: 0,
+    position_mode: "relative_to_group_anchor",
+    subcircuit_id: "subcircuit_source_group_0",
+  },
+  {
+    type: "pcb_port",
+    pcb_port_id: "pcb_port_0",
+    pcb_component_id: "pcb_component_0",
+    source_port_id: "source_port_0",
+    layers: ["top"],
+    x: 1,
+    y: 2,
+    subcircuit_id: "subcircuit_source_group_0",
+  },
+  {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: "pcb_smtpad_0",
+    pcb_component_id: "pcb_component_0",
+    pcb_port_id: "pcb_port_0",
+    layer: "top",
+    shape: "pill",
+    width: 0.36,
+    height: 1.74,
+    radius: 0.18,
+    x: 1,
+    y: 2,
+    port_hints: ["pin1"],
+    is_covered_with_solder_mask: false,
+    subcircuit_id: "subcircuit_source_group_0",
+  },
+] as CircuitJson
+
+test("extractPadInfos handles pill-shaped SMT pads", () => {
+  const db = cju(pillPadCircuitJson)
+  const pcbComponent = db.pcb_component.get("pcb_component_0")
+
+  const pads = extractPadInfos(
+    pcbComponent as PcbComponent,
+    db,
+    (pcbPortId) => pcbPortId ?? "",
+  )
+
+  expect(pads).toEqual([
+    {
+      padId: "pcb_smtpad_0",
+      networkId: "pcb_port_0",
+      size: { x: 0.36, y: 1.74 },
+      absoluteCenter: { x: 1, y: 2 },
+      pcbPortId: "pcb_port_0",
+    },
+  ])
+})
+
+test("fixed components with only pill-shaped SMT pads become packing obstacles", () => {
+  const packOutput = convertCircuitJsonToPackOutput(pillPadCircuitJson, {
+    source_group_id: "source_group_0",
+  })
+
+  const obstacle = packOutput.obstacles?.find(
+    ({ obstacleId }) => obstacleId === "pcb_component_0",
+  )
+
+  expect(obstacle).toBeDefined()
+  expect(obstacle?.absoluteCenter).toEqual({ x: 1, y: 2 })
+  expect(obstacle?.width).toBeCloseTo(0.36)
+  expect(obstacle?.height).toBeCloseTo(1.74)
+})


### PR DESCRIPTION
## Summary

Fix PCB packing for components whose footprints use pill-shaped SMT pads.

`extractPadInfos` previously supported rectangular, circular, and polygon SMT pads, but silently omitted `pill` pads. As a result, fixed components containing only pill-shaped pads produced no pad geometry and could disappear from the packing obstacle model. Automatically placed components could then overlap them.

## Changes

- Extract pill-shaped SMT pads using their width, height, and center.
- Preserve their PCB port and network mapping.
- Ensure fixed `relative_to_group_anchor` components with pill-only footprints generate packing obstacles.
- Add focused unit and integration regression coverage.

## Bug reproduction

The regression test models a fixed component whose footprint contains only a pill-shaped SMT pad.

Before this change:

- `extractPadInfos` returned an empty array.
- The fixed component was omitted from packing obstacles.
- Automatic placement could place another component inside its physical area.

After this change:

- The pill pad is represented with the correct dimensions and position.
- The fixed component produces the expected packing obstacle.
- The placer can keep automatically positioned components outside its occupied area.

## Tests

- Verifies pill-pad dimensions, position, port ID, and network mapping.
- Verifies a fixed pill-only component becomes a packing obstacle.
- Full test suite: 108 passed, 10 skipped, 0 failed.
- Typecheck passed.
- Package build and declaration generation passed.
- Formatting passed.
