### PR TITLE
Fix fixed-component packing obstacles to respect PCB courtyards

### DIFF
--- a/lib/plumbing/convertCircuitJsonToPackOutput.ts
+++ b/lib/plumbing/convertCircuitJsonToPackOutput.ts
@@ -342,6 +342,25 @@ export const convertCircuitJsonToPackOutput = (
   )
 
   for (const pcbComponent of relativeComponents) {
+    const courtyard = extractCourtyardForComponent({
+      db,
+      pcbComponentIds: [pcbComponent.pcb_component_id],
+      componentCenter: pcbComponent.center,
+    })
+
+    if (courtyard) {
+      packOutput.obstacles!.push({
+        obstacleId: pcbComponent.pcb_component_id,
+        absoluteCenter: {
+          x: pcbComponent.center.x + courtyard.offsetFromCenter.x,
+          y: pcbComponent.center.y + courtyard.offsetFromCenter.y,
+        },
+        width: courtyard.width,
+        height: courtyard.height,
+      })
+      continue
+    }
+
     // Get all pads for this component to determine its bounds
     const padInfos = extractPadInfos(pcbComponent, db, getNetworkId)
 

--- a/tests/courtyard-packing.test.ts
+++ b/tests/courtyard-packing.test.ts
@@ -80,6 +80,86 @@ test("convertCircuitJsonToPackOutput extracts pcb_courtyard_rect", () => {
   })
 })
 
+test("fixed components use courtyard bounds as packing obstacles", () => {
+  const circuitJson = [
+    {
+      type: "source_group",
+      source_group_id: "root",
+      name: "root",
+    },
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      source_group_id: "root",
+      name: "J1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "sp1",
+      source_component_id: "sc1",
+      name: "1",
+    },
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 1, y: 2 },
+      rotation: 0,
+      width: 1,
+      height: 1,
+      layer: "top",
+      position_mode: "relative_to_group_anchor",
+    },
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp1",
+      pcb_component_id: "pc1",
+      source_port_id: "sp1",
+      x: 1,
+      y: 2,
+      layers: ["top"],
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      pcb_component_id: "pc1",
+      pcb_port_id: "pp1",
+      shape: "rect",
+      x: 1,
+      y: 2,
+      width: 1,
+      height: 1,
+      layer: "top",
+    },
+    {
+      type: "pcb_courtyard_outline",
+      pcb_courtyard_outline_id: "cy1",
+      pcb_component_id: "pc1",
+      outline: [
+        { x: -2, y: 1 },
+        { x: 8, y: 1 },
+        { x: 8, y: 7 },
+        { x: -2, y: 7 },
+      ],
+      layer: "top",
+    },
+  ] as any
+
+  const result = convertCircuitJsonToPackOutput(circuitJson, {
+    source_group_id: "root",
+  })
+
+  expect(result.obstacles).toEqual([
+    {
+      obstacleId: "pc1",
+      absoluteCenter: { x: 3, y: 4 },
+      width: 10,
+      height: 6,
+    },
+  ])
+})
+
 test("overlapping courtyards are detected even when pads don't overlap", () => {
   // Two components with small pads (1x1) but large courtyards (6x4)
   // Placed 4mm apart: pads have 3mm gap, but courtyards overlap by 2mm


### PR DESCRIPTION
## Summary

Fix packing obstacle generation for fixed PCB components by using their courtyard bounds instead of only their pad bounds.

Fixed components using `position_mode: "relative_to_group_anchor"` previously produced obstacles based solely on their pads. This allowed automatically packed components to enter the larger courtyard area and caused courtyard overlap errors even though the packing result appeared valid.

## Root cause

The circuit JSON conversion path handled courtyard geometry for packed components, but fixed relative components always fell back to pad-derived bounds. Components such as connectors and ICs can have courtyards that extend well beyond their pads, so those obstacles understated the reserved PCB area.

## Changes

- Extract courtyard geometry for fixed components during circuit JSON conversion
- Generate an accurately positioned obstacle from the courtyard dimensions and offset
- Preserve pad-bound obstacle generation as a fallback for components without courtyards
- Avoid generating duplicate pad and courtyard obstacles for the same fixed component

## Bug reproduction

Added a regression test with:

- A fixed component using relative positioning
- A small SMT pad
- A larger, offset courtyard outline

The test verifies that the resulting packing obstacle uses the courtyard's full dimensions and absolute center rather than the smaller pad bounds.

## Impact

This improves packing obstacle accuracy for connectors, ICs, and other fixed components with courtyards larger than their pads. It prevents auto-placed components from being packed inside reserved component-clearance areas.

The issue was reproduced on the SparkFun RS232 Breakout, where capacitors could be placed inside the courtyards of the fixed transceiver and DB9 connector.

## Validation

- 109 tests passed
- 10 tests skipped
- Typecheck passed
- Build passed
- Formatting checks passed
- Verified against the SparkFun RS232 Breakout circuit
