### PR TITLE
Avoid duplicate obstacles for packed nested groups

### DIFF
--- a/lib/plumbing/convertCircuitJsonToPackOutput.ts
+++ b/lib/plumbing/convertCircuitJsonToPackOutput.ts
@@ -12,6 +12,8 @@ import { extractPadInfos } from "./extractPadInfos"
 import { getElementOutsideTree } from "./getElementsOutsideTree"
 import { getObstacleFromElement } from "./getObstacleFromElement"
 
+type PcbComponentId = PcbComponent["pcb_component_id"]
+
 /**
  * Extract a bounding-box courtyard for a set of pcb_component_ids using the db.
  * Supports pcb_courtyard_rect, pcb_courtyard_polygon, pcb_courtyard_outline,
@@ -281,7 +283,7 @@ export const convertCircuitJsonToPackOutput = (
   }
 
   const staticComponentIds = new Set(opts.staticPcbComponentIds ?? [])
-  const pcbComponentIdsRepresentedByPackedGroups = new Set<string>()
+  const pcbComponentIdsRepresentedByPackedGroups = new Set<PcbComponentId>()
 
   for (const node of topLevelNodes) {
     if (node.nodeType === "component") {

--- a/lib/plumbing/convertCircuitJsonToPackOutput.ts
+++ b/lib/plumbing/convertCircuitJsonToPackOutput.ts
@@ -1,12 +1,12 @@
-import type { CircuitJson, PcbComponent } from "circuit-json"
 import { cju, getCircuitJsonTree } from "@tscircuit/circuit-json-util"
+import type { CircuitJson, PcbComponent } from "circuit-json"
 import type {
+  ComponentCourtyard,
+  InputObstacle,
   OutputPad,
   PackedComponent,
   PackInput,
   PackOutput,
-  InputObstacle,
-  ComponentCourtyard,
 } from "../types"
 import { extractPadInfos } from "./extractPadInfos"
 import { getElementOutsideTree } from "./getElementsOutsideTree"
@@ -281,6 +281,7 @@ export const convertCircuitJsonToPackOutput = (
   }
 
   const staticComponentIds = new Set(opts.staticPcbComponentIds ?? [])
+  const pcbComponentIdsRepresentedByPackedGroups = new Set<string>()
 
   for (const node of topLevelNodes) {
     if (node.nodeType === "component") {
@@ -317,6 +318,11 @@ export const convertCircuitJsonToPackOutput = (
     } else if (node.nodeType === "group") {
       const pcbComps = collectPcbComponents(node, db)
       if (!pcbComps.length) continue
+      for (const pcbComponent of pcbComps) {
+        pcbComponentIdsRepresentedByPackedGroups.add(
+          pcbComponent.pcb_component_id,
+        )
+      }
       const compId =
         node.sourceGroup?.source_group_id ??
         node.sourceGroup?.name ??
@@ -342,6 +348,17 @@ export const convertCircuitJsonToPackOutput = (
   )
 
   for (const pcbComponent of relativeComponents) {
+    // A top-level group is represented as one aggregate packed component. Its
+    // relatively positioned descendants are already part of that aggregate and
+    // must not also be emitted as fixed obstacles.
+    if (
+      pcbComponentIdsRepresentedByPackedGroups.has(
+        pcbComponent.pcb_component_id,
+      )
+    ) {
+      continue
+    }
+
     const courtyard = extractCourtyardForComponent({
       db,
       pcbComponentIds: [pcbComponent.pcb_component_id],

--- a/tests/circuit-json-pack-conversion/nested-group-obstacles.test.ts
+++ b/tests/circuit-json-pack-conversion/nested-group-obstacles.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "bun:test"
+import type { CircuitJson } from "circuit-json"
+import { convertCircuitJsonToPackOutput } from "../../lib/plumbing/convertCircuitJsonToPackOutput"
+
+const makeComponentElements = ({
+  componentNumber,
+  sourceGroupId,
+  positionMode,
+  x,
+}: {
+  componentNumber: number
+  sourceGroupId: string
+  positionMode: "relative_to_group_anchor"
+  x: number
+}) => [
+  {
+    type: "source_component",
+    source_component_id: `source_component_${componentNumber}`,
+    source_group_id: sourceGroupId,
+    name: `R${componentNumber}`,
+    ftype: "simple_resistor",
+  },
+  {
+    type: "source_port",
+    source_port_id: `source_port_${componentNumber}`,
+    source_component_id: `source_component_${componentNumber}`,
+    name: "pin1",
+  },
+  {
+    type: "pcb_component",
+    pcb_component_id: `pcb_component_${componentNumber}`,
+    source_component_id: `source_component_${componentNumber}`,
+    center: { x, y: 0 },
+    rotation: 0,
+    width: 1,
+    height: 1,
+    layer: "top",
+    position_mode: positionMode,
+  },
+  {
+    type: "pcb_port",
+    pcb_port_id: `pcb_port_${componentNumber}`,
+    pcb_component_id: `pcb_component_${componentNumber}`,
+    source_port_id: `source_port_${componentNumber}`,
+    x,
+    y: 0,
+    layers: ["top"],
+  },
+  {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: `pcb_smtpad_${componentNumber}`,
+    pcb_component_id: `pcb_component_${componentNumber}`,
+    pcb_port_id: `pcb_port_${componentNumber}`,
+    shape: "rect",
+    x,
+    y: 0,
+    width: 1,
+    height: 1,
+    layer: "top",
+  },
+]
+
+test("nested-group members are not duplicated as packing obstacles", () => {
+  const circuitJson = [
+    {
+      type: "source_group",
+      source_group_id: "root",
+      name: "root",
+    },
+    {
+      type: "source_group",
+      source_group_id: "nested_group",
+      parent_source_group_id: "root",
+      name: "nested_group",
+    },
+    ...makeComponentElements({
+      componentNumber: 1,
+      sourceGroupId: "nested_group",
+      positionMode: "relative_to_group_anchor",
+      x: -1,
+    }),
+    ...makeComponentElements({
+      componentNumber: 2,
+      sourceGroupId: "nested_group",
+      positionMode: "relative_to_group_anchor",
+      x: 1,
+    }),
+    ...makeComponentElements({
+      componentNumber: 3,
+      sourceGroupId: "root",
+      positionMode: "relative_to_group_anchor",
+      x: 4,
+    }),
+  ] as CircuitJson
+
+  const packOutput = convertCircuitJsonToPackOutput(circuitJson, {
+    source_group_id: "root",
+  })
+
+  expect(packOutput.components.map(({ componentId }) => componentId)).toEqual([
+    "nested_group",
+  ])
+  expect(packOutput.obstacles?.map(({ obstacleId }) => obstacleId)).toEqual([
+    "pcb_component_3",
+  ])
+})


### PR DESCRIPTION
## Summary

- make `convertCircuitJsonToPackOutput` track PCB components already represented by a top-level packed-group aggregate
- skip fixed-obstacle emission for relatively positioned descendants already contained by that aggregate
- preserve fixed obstacles for relatively positioned components directly under the packing root
- add a focused converter regression test covering both cases

## Why

A nested group is converted into one aggregate `PackedComponent`, but its relatively positioned member components were also emitted as fixed obstacles. The solver therefore saw the same physical geometry twice: once inside the movable group and once as immovable board geometry.

The deduplication belongs at the Circuit JSON → pack-output boundary, where both representations are created and their membership is known. This is the upstream fix needed by [tscircuit/core#2808](https://github.com/tscircuit/core/pull/2808); core should not mutate `PackOutput` after conversion.

## Validation

- `bun test` — 116 pass, 10 skip, 0 fail
- `bun run typecheck`
- `bunx biome check lib/plumbing/convertCircuitJsonToPackOutput.ts tests/circuit-json-pack-conversion/nested-group-obstacles.test.ts`