### PR TITLE
feat: support mustBeOnBoundary constraint

### DIFF
--- a/lib/OutlineSegmentCandidatePointSolver/OutlineSegmentCandidatePointSolver.ts
+++ b/lib/OutlineSegmentCandidatePointSolver/OutlineSegmentCandidatePointSolver.ts
@@ -18,11 +18,12 @@ import { isStrongConnection } from "lib/utils/isStrongConnection"
 import { rotatePoint } from "lib/math/rotatePoint"
 import { getComponentBounds } from "lib/geometry/getComponentBounds"
 import { getColorForString } from "lib/testing/createColorMapFromStrings"
-import { getOutwardNormal } from "./getOutwardNormal"
+import { getInteriorNormal, getOutwardNormal } from "./getOutwardNormal"
 import { LargestRectOutsideOutlineFromPointSolver } from "lib/LargestRectOutsideOutlineFromPointSolver"
 import { getInputComponentBounds } from "lib/geometry/getInputComponentBounds"
 import { expandSegment } from "lib/math/expandSegment"
 import { isPointInPolygon } from "lib/math/isPointInPolygon"
+import { getComponentCollisionBoxes } from "lib/PackSolver2/getComponentCollisionBoxes"
 
 /**
  * Given a single segment on the outline, the component's rotation, compute the
@@ -47,6 +48,8 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
   viableBounds?: Bounds
   globalBounds?: Bounds
   boundaryOutline?: Array<{ x: number; y: number }>
+  isBoardBoundarySegment: boolean
+  relativeCollisionCorners: Point[] = []
   weightedConnections?: PackInput["weightedConnections"]
   optimalPosition?: Point
   irlsSolver?: MultiOffsetIrlsSolver
@@ -71,6 +74,7 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
     obstacles?: InputObstacle[]
     globalBounds?: Bounds
     boundaryOutline?: Array<{ x: number; y: number }>
+    isBoardBoundarySegment?: boolean
     weightedConnections?: PackInput["weightedConnections"]
   }) {
     super()
@@ -84,6 +88,7 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
     this.obstacles = params.obstacles ?? []
     this.globalBounds = params.globalBounds
     this.boundaryOutline = params.boundaryOutline
+    this.isBoardBoundarySegment = params.isBoardBoundarySegment ?? false
     this.weightedConnections = params.weightedConnections
   }
 
@@ -101,6 +106,7 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
       obstacles: this.obstacles,
       globalBounds: this.globalBounds,
       boundaryOutline: this.boundaryOutline,
+      isBoardBoundarySegment: this.isBoardBoundarySegment,
       weightedConnections: this.weightedConnections,
     }
   }
@@ -132,6 +138,11 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
     // Get pad offset points and target point mappings
     const { offsetPadPoints, targetPointMap } =
       this.getNetworkTargetPointMappings()
+
+    if (this.isBoardBoundarySegment) {
+      this.setupBoardBoundaryPlacement(offsetPadPoints, targetPointMap)
+      return
+    }
 
     const [p1, p2] = this.outlineSegment
 
@@ -284,21 +295,102 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
       y: (vp1.y + vp2.y) / 2,
     })
 
+    this.setupPositionOptimizer({
+      offsetPadPoints,
+      targetPointMap,
+      initialPosition,
+      constraintFn,
+    })
+  }
+
+  private setupBoardBoundaryPlacement(
+    offsetPadPoints: OffsetPadPoint[],
+    targetPointMap: Map<string, Point[]>,
+  ): void {
+    const [start, end] = this.outlineSegment
+    const segmentLength = Math.hypot(end.x - start.x, end.y - start.y)
+    if (segmentLength === 0) {
+      this.failed = true
+      this.error = "Cannot place a component along a zero-length boundary"
+      return
+    }
+
+    const tangent = {
+      x: (end.x - start.x) / segmentLength,
+      y: (end.y - start.y) / segmentLength,
+    }
+    this.relativeCollisionCorners = getComponentCollisionBoxes(
+      this.createTemporaryPackedComponent({ x: 0, y: 0 }),
+    ).flatMap((box) => {
+      const halfWidth = box.width / 2
+      const halfHeight = box.height / 2
+      return [
+        { x: box.center.x - halfWidth, y: box.center.y - halfHeight },
+        { x: box.center.x - halfWidth, y: box.center.y + halfHeight },
+        { x: box.center.x + halfWidth, y: box.center.y - halfHeight },
+        { x: box.center.x + halfWidth, y: box.center.y + halfHeight },
+      ]
+    })
+    const tangentProjections = this.relativeCollisionCorners.map(
+      (corner) => corner.x * tangent.x + corner.y * tangent.y,
+    )
+    const startDistance = Math.max(0, -Math.min(...tangentProjections))
+    const endDistance = Math.min(
+      segmentLength,
+      segmentLength - Math.max(...tangentProjections),
+    )
+
+    if (startDistance > endDistance) {
+      this.failed = true
+      this.error =
+        "There is nowhere for the component to fit along this boundary section"
+      return
+    }
+
+    this.viableOutlineSegment = [
+      {
+        x: start.x + tangent.x * startDistance,
+        y: start.y + tangent.y * startDistance,
+      },
+      {
+        x: start.x + tangent.x * endDistance,
+        y: start.y + tangent.y * endDistance,
+      },
+    ]
+
+    const constraintFn = (point: Point): Point =>
+      this.adjustPositionForOutlineCollision(
+        this.projectPointOntoSegment(point, this.viableOutlineSegment!),
+      )
+    const [viableStart, viableEnd] = this.viableOutlineSegment
+    const initialPosition = this.adjustPositionForOutlineCollision({
+      x: (viableStart.x + viableEnd.x) / 2,
+      y: (viableStart.y + viableEnd.y) / 2,
+    })
+
+    this.setupPositionOptimizer({
+      offsetPadPoints,
+      targetPointMap,
+      initialPosition,
+      constraintFn,
+    })
+  }
+
+  private setupPositionOptimizer(params: {
+    offsetPadPoints: OffsetPadPoint[]
+    targetPointMap: Map<string, Point[]>
+    initialPosition: Point
+    constraintFn: (point: Point) => Point
+  }): void {
     if (this.packStrategy === "minimum_closest_sum_squared_distance") {
       this.twoPhaseIrlsSolver = new TwoPhaseIrlsSolver({
-        offsetPadPoints,
-        targetPointMap,
-        initialPosition,
-        constraintFn,
+        ...params,
         epsilon: 1e-6,
         maxIterations: 50,
       })
     } else {
       this.irlsSolver = new MultiOffsetIrlsSolver({
-        offsetPadPoints,
-        targetPointMap,
-        initialPosition,
-        constraintFn,
+        ...params,
         epsilon: 1e-6,
         maxIterations: 50,
         useSquaredDistance:
@@ -467,6 +559,22 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
    * and ensure the component stays within the boundary outline
    */
   private adjustPositionForOutlineCollision(center: Point): Point {
+    if (this.isBoardBoundarySegment) {
+      const inwardNormal = getInteriorNormal(
+        this.outlineSegment,
+        this.ccwFullOutline,
+      )
+      const minimumProjection = Math.min(
+        ...this.relativeCollisionCorners.map(
+          (corner) => corner.x * inwardNormal.x + corner.y * inwardNormal.y,
+        ),
+      )
+      return {
+        x: center.x - inwardNormal.x * minimumProjection,
+        y: center.y - inwardNormal.y * minimumProjection,
+      }
+    }
+
     // Create temporary component at this position
     const tempComponent = this.createTemporaryPackedComponent(center)
 

--- a/lib/OutlineSegmentCandidatePointSolver/getOutwardNormal.ts
+++ b/lib/OutlineSegmentCandidatePointSolver/getOutwardNormal.ts
@@ -1,5 +1,27 @@
 import type { Point } from "@tscircuit/math-utils"
 
+/** Get the normal pointing inside a closed outline, regardless of winding. */
+export function getInteriorNormal(
+  outlineSegment: [Point, Point],
+  fullOutline: [Point, Point][],
+): Point {
+  const [start, end] = outlineSegment
+  const dx = end.x - start.x
+  const dy = end.y - start.y
+  const length = Math.hypot(dx, dy)
+  if (length === 0) return { x: 0, y: 1 }
+
+  const signedArea =
+    fullOutline.reduce(
+      (area, [p1, p2]) => area + p1.x * p2.y - p2.x * p1.y,
+      0,
+    ) / 2
+
+  return signedArea >= 0
+    ? { x: -dy / length, y: dx / length }
+    : { x: dy / length, y: -dx / length }
+}
+
 /**
  * Get the normal direction pointing toward FREE SPACE for component placement.
  *

--- a/lib/PackSolver2/PackSolver2.ts
+++ b/lib/PackSolver2/PackSolver2.ts
@@ -88,6 +88,7 @@ export class PackSolver2 extends BaseSolver {
 
   private packFirstComponent(): void {
     const firstComponentToPack = this.unpackedComponentQueue.shift()!
+    const mustBeOnBoundary = firstComponentToPack.mustBeOnBoundary === true
 
     // If boundary outline exists, use its geometric centroid as the starting position
     let initialPosition = { x: 0, y: 0 }
@@ -154,7 +155,7 @@ export class PackSolver2 extends BaseSolver {
       outsideBoundaryOutline = !allPadsInside || !cornersInside
     }
 
-    if (!tooCloseToObstacles && !outsideBoundaryOutline) {
+    if (!mustBeOnBoundary && !tooCloseToObstacles && !outsideBoundaryOutline) {
       this.packedComponents.push(newPackedComponent)
       return
     }
@@ -174,6 +175,11 @@ export class PackSolver2 extends BaseSolver {
     const result = fallbackSolver.getResult()
     if (result) {
       this.packedComponents.push(result)
+    } else if (mustBeOnBoundary) {
+      this.failed = true
+      this.error =
+        fallbackSolver.error ??
+        `Could not place component ${firstComponentToPack.componentId} on the boundary`
     } else {
       // Fallback: place at center even if it violates constraints (should rarely happen)
       // This typically indicates impossible constraints (e.g., component too large for boundary)
@@ -224,6 +230,7 @@ export class PackSolver2 extends BaseSolver {
 
     if (this.activeSubSolver.failed) {
       this.failed = true
+      this.error = this.activeSubSolver.error
       return
     }
 

--- a/lib/SingleComponentPackSolver/SingleComponentPackSolver.ts
+++ b/lib/SingleComponentPackSolver/SingleComponentPackSolver.ts
@@ -16,8 +16,8 @@ import { isStrongConnection } from "../utils/isStrongConnection"
 import { checkOverlapWithPackedComponents } from "lib/PackSolver2/checkOverlapWithPackedComponents"
 import { getComponentCollisionBoxes } from "lib/PackSolver2/getComponentCollisionBoxes"
 import { computeDistanceBetweenBoxes, type Bounds } from "@tscircuit/math-utils"
-import { isPointInPolygon } from "lib/math/isPointInPolygon"
 import { getComponentBounds } from "lib/geometry/getComponentBounds"
+import { pointInOutline } from "lib/geometry/pointInOutline"
 
 type Phase = "outline" | "segment_candidate" | "evaluate"
 
@@ -26,6 +26,7 @@ interface QueuedOutlineSegment {
   availableRotations: number[]
   segmentIndex: number
   ccwFullOutline: Segment[] // The entire outline containing this segment
+  isBoardBoundarySegment?: boolean
 }
 
 interface CandidateResult {
@@ -125,8 +126,18 @@ export class SingleComponentPackSolver extends BaseSolver {
   }
 
   private executeOutlinePhase() {
+    const mustBeOnBoundary = this.componentToPack.mustBeOnBoundary === true
+    if (
+      mustBeOnBoundary &&
+      (!this.boundaryOutline || this.boundaryOutline.length < 3)
+    ) {
+      this.failed = true
+      this.error = `Component ${this.componentToPack.componentId} requires a boundaryOutline`
+      return
+    }
+
     // Special case: if no packed components, attempt center; if too close to obstacles, fall back to outline-based placement
-    if (this.packedComponents.length === 0) {
+    if (this.packedComponents.length === 0 && !mustBeOnBoundary) {
       const availableRotations = this.componentToPack
         .availableRotationDegrees ?? [0, 90, 180, 270]
       const position = { x: 0, y: 0 }
@@ -156,13 +167,12 @@ export class SingleComponentPackSolver extends BaseSolver {
     }
 
     // Construct outlines from packed components (and obstacles)
-    this.outlines = constructOutlinesFromPackedComponents(
-      this.packedComponents,
-      {
-        minGap: this.minGap,
-        obstacles: this.obstacles,
-      },
-    )
+    this.outlines = mustBeOnBoundary
+      ? []
+      : constructOutlinesFromPackedComponents(this.packedComponents, {
+          minGap: this.minGap,
+          obstacles: this.obstacles,
+        })
 
     // Queue all segment-rotation pairs
     const availableRotations = this.componentToPack
@@ -205,8 +215,14 @@ export class SingleComponentPackSolver extends BaseSolver {
           availableRotations: [...availableRotations],
           segmentIndex: boundaryOutlineIndex * 1000 + i,
           ccwFullOutline: boundarySegments,
+          isBoardBoundarySegment: mustBeOnBoundary,
         })
       }
+    }
+
+    if (mustBeOnBoundary) {
+      this.currentPhase = "segment_candidate"
+      return
     }
 
     // Add obstacle boundary segments for isolated obstacles
@@ -307,23 +323,65 @@ export class SingleComponentPackSolver extends BaseSolver {
 
         // Check if component is outside boundary outline
         let outsideBoundaryOutline = false
+        let doesNotTouchBoundary = false
         if (this.boundaryOutline && this.boundaryOutline.length >= 3) {
           const componentBounds = getComponentBounds(candidateComponent, 0)
+          const boundarySegments = this.boundaryOutline.map(
+            (point, index) =>
+              [
+                point,
+                this.boundaryOutline![
+                  (index + 1) % this.boundaryOutline!.length
+                ]!,
+              ] as Segment,
+          )
+          const getBoardLocation = (point: Point) =>
+            pointInOutline(point, boundarySegments)
 
           // Check if all pads are within the boundary outline
-          const allPadsInside = candidateComponent.pads.every((pad) =>
-            isPointInPolygon(pad.absoluteCenter, this.boundaryOutline!),
+          const allPadsInside = candidateComponent.pads.every(
+            (pad) => getBoardLocation(pad.absoluteCenter) !== "outside",
           )
 
           // Also check corners of component bounds
-          const cornersInside = [
+          const corners = [
             { x: componentBounds.minX, y: componentBounds.minY },
             { x: componentBounds.minX, y: componentBounds.maxY },
             { x: componentBounds.maxX, y: componentBounds.minY },
             { x: componentBounds.maxX, y: componentBounds.maxY },
-          ].every((corner) => isPointInPolygon(corner, this.boundaryOutline!))
+          ]
+          const cornersInside = corners.every(
+            (corner) => getBoardLocation(corner) !== "outside",
+          )
+          const collisionCorners = candidateCollisionBoxes.flatMap((box) => {
+            const halfWidth = box.width / 2
+            const halfHeight = box.height / 2
+            return [
+              {
+                x: box.center.x - halfWidth,
+                y: box.center.y - halfHeight,
+              },
+              {
+                x: box.center.x - halfWidth,
+                y: box.center.y + halfHeight,
+              },
+              {
+                x: box.center.x + halfWidth,
+                y: box.center.y - halfHeight,
+              },
+              {
+                x: box.center.x + halfWidth,
+                y: box.center.y + halfHeight,
+              },
+            ]
+          })
 
           outsideBoundaryOutline = !allPadsInside || !cornersInside
+          doesNotTouchBoundary =
+            this.componentToPack.mustBeOnBoundary === true &&
+            !collisionCorners.some(
+              (corner) => getBoardLocation(corner) === "boundary",
+            )
         }
 
         // Calculate distance based on pack strategy
@@ -368,6 +426,16 @@ export class SingleComponentPackSolver extends BaseSolver {
             segmentIndex: queuedSegment.segmentIndex,
             rotationIndex: this.currentRotationIndex,
             gapDistance: -1, // Special marker for boundary violation
+          })
+        } else if (doesNotTouchBoundary) {
+          this.rejectedCandidates.push({
+            segment: queuedSegment.segment,
+            rotation,
+            optimalPosition,
+            distance,
+            segmentIndex: queuedSegment.segmentIndex,
+            rotationIndex: this.currentRotationIndex,
+            gapDistance: -2, // Special marker for mustBeOnBoundary violation
           })
         } else {
           // Store candidate result
@@ -421,6 +489,7 @@ export class SingleComponentPackSolver extends BaseSolver {
         obstacles: this.obstacles,
         globalBounds: this.bounds,
         boundaryOutline: this.boundaryOutline,
+        isBoardBoundarySegment: queuedSegment.isBoardBoundarySegment,
         weightedConnections: this.weightedConnections,
       })
 

--- a/lib/plumbing/convertPackOutputToPackInput.ts
+++ b/lib/plumbing/convertPackOutputToPackInput.ts
@@ -23,6 +23,7 @@ export const convertPackOutputToPackInput = (packed: PackOutput): PackInput => {
       : {
           componentId: pc.componentId,
           availableRotationDegrees: pc.availableRotationDegrees, // Preserve rotation constraints
+          mustBeOnBoundary: pc.mustBeOnBoundary,
           pads: pc.pads.map(({ absoluteCenter: _ac, ...rest }) => rest),
           courtyard: pc.courtyard,
         }),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -25,6 +25,8 @@ export interface InputComponent {
   componentId: string
   /** Components marked as static are not moved by the packer */
   isStatic?: boolean
+  /** Require the component to be placed inside and against boundaryOutline. */
+  mustBeOnBoundary?: boolean
   /**
    * If not provided, the component can be rotated by 0, 90, 180, or 270 degrees.
    */

--- a/tests/__snapshots__/must-be-on-boundary.visual.snap.svg
+++ b/tests/__snapshots__/must-be-on-boundary.visual.snap.svg
@@ -1,0 +1,46 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-12,-8 -12,8 12,8 12,-4 8,-8 -12,-8" data-type="line" data-label="" points="40,506.66666666666663 40,133.33333333333334 600,133.33333333333334 600,413.3333333333333 506.66666666666663,506.66666666666663 40,506.66666666666663" fill="none" stroke="rgba(0, 0, 255, 0.5)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="-11,0 -5.5,0" data-type="line" data-label="" points="63.33333333333337,320 191.66666666666669,320" fill="none" stroke="hsl(0, 100%, 50%)" stroke-width="1px"/></g><g><polyline data-points="-9,0 -3.5,0" data-type="line" data-label="" points="110,320 238.33333333333334,320" fill="none" stroke="hsl(150, 100%, 50%)" stroke-width="1px"/></g><g><rect data-type="rect" data-label="USB_EDGE
+ccwRotationOffset: 0.0°" data-x="-10" data-y="0" x="40.000000000000014" y="296.6666666666667" width="93.33333333333334" height="46.66666666666663" fill="rgba(0,0,0,0.25)" stroke="black" stroke-width="0.04285714285714286"/></g><g><rect data-type="rect" data-label="USB_DP DP" data-x="-11" data-y="0" x="51.666666666666714" y="308.3333333333333" width="23.333333333333314" height="23.33333333333337" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.04285714285714286"/></g><g><rect data-type="rect" data-label="USB_DM DM" data-x="-9" data-y="0" x="98.33333333333333" y="308.3333333333333" width="23.333333333333343" height="23.33333333333337" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.04285714285714286"/></g><g><rect data-type="rect" data-label="MCU
+ccwRotationOffset: 0.0°" data-x="-4.5" data-y="1.5" x="156.66666666666669" y="226.66666666666669" width="116.66666666666663" height="116.66666666666663" fill="rgba(0,0,0,0.25)" stroke="black" stroke-width="0.04285714285714286"/></g><g><rect data-type="rect" data-label="MCU_DP DP" data-x="-5.5" data-y="0" x="180" y="308.3333333333333" width="23.333333333333343" height="23.33333333333337" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.04285714285714286"/></g><g><rect data-type="rect" data-label="MCU_DM DM" data-x="-3.5" data-y="0" x="226.66666666666669" y="308.3333333333333" width="23.333333333333314" height="23.33333333333337" fill="rgba(255,0,0,0.8)" stroke="black" stroke-width="0.04285714285714286"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":23.333333333333332,"c":0,"e":320,"b":0,"d":-23.333333333333332,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/convert-pack-output-to-input.test.ts
+++ b/tests/convert-pack-output-to-input.test.ts
@@ -10,6 +10,7 @@ test("convertPackOutputToPackInput should preserve availableRotationDegrees", ()
         center: { x: 0, y: 0 },
         ccwRotationOffset: 0,
         availableRotationDegrees: [0], // Should be preserved
+        mustBeOnBoundary: true,
         pads: [
           {
             padId: "U1_P1",
@@ -48,6 +49,7 @@ test("convertPackOutputToPackInput should preserve availableRotationDegrees", ()
   // Should preserve availableRotationDegrees
   expect(packInput.components[0]?.availableRotationDegrees).toEqual([0])
   expect(packInput.components[1]?.availableRotationDegrees).toEqual([0, 90])
+  expect(packInput.components[0]?.mustBeOnBoundary).toBe(true)
 
   // Should remove output-only properties
   expect(packInput.components[0]).not.toHaveProperty("center")

--- a/tests/must-be-on-boundary.visual.test.ts
+++ b/tests/must-be-on-boundary.visual.test.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "bun:test"
+import { getSvgFromGraphicsObject } from "graphics-debug"
+import { getComponentBounds } from "../lib/geometry/getComponentBounds"
+import { pointInOutline } from "../lib/geometry/pointInOutline"
+import type { Segment } from "../lib/geometry/types"
+import { PackSolver2 } from "../lib/PackSolver2/PackSolver2"
+import { getGraphicsFromPackOutput } from "../lib/testing/getGraphicsFromPackOutput"
+import type { PackInput, PackOutput } from "../lib/types"
+
+test("boundary-constrained component placement - visual regression", () => {
+  const boundaryOutline = [
+    { x: -12, y: -8 },
+    { x: -12, y: 8 },
+    { x: 12, y: 8 },
+    { x: 12, y: -4 },
+    { x: 8, y: -8 },
+  ]
+  const packInput: PackInput = {
+    components: [
+      {
+        componentId: "USB_EDGE",
+        mustBeOnBoundary: true,
+        availableRotationDegrees: [0, 90],
+        courtyard: {
+          offsetFromCenter: { x: 0, y: 0 },
+          width: 4,
+          height: 2,
+        },
+        pads: [
+          {
+            padId: "USB_DP",
+            networkId: "DP",
+            type: "rect",
+            offset: { x: -1, y: 0 },
+            size: { x: 1, y: 1 },
+          },
+          {
+            padId: "USB_DM",
+            networkId: "DM",
+            type: "rect",
+            offset: { x: 1, y: 0 },
+            size: { x: 1, y: 1 },
+          },
+        ],
+      },
+      {
+        componentId: "MCU",
+        availableRotationDegrees: [0],
+        courtyard: {
+          offsetFromCenter: { x: 0, y: 0 },
+          width: 5,
+          height: 5,
+        },
+        pads: [
+          {
+            padId: "MCU_DP",
+            networkId: "DP",
+            type: "rect",
+            offset: { x: -1, y: -1.5 },
+            size: { x: 1, y: 1 },
+          },
+          {
+            padId: "MCU_DM",
+            networkId: "DM",
+            type: "rect",
+            offset: { x: 1, y: -1.5 },
+            size: { x: 1, y: 1 },
+          },
+        ],
+      },
+    ],
+    boundaryOutline,
+    minGap: 1,
+    packOrderStrategy: "largest_to_smallest",
+    packPlacementStrategy: "minimum_sum_squared_distance_to_network",
+  }
+
+  const solver = new PackSolver2(packInput)
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(solver.solved).toBe(true)
+
+  const edgeComponent = solver.packedComponents.find(
+    (component) => component.componentId === "USB_EDGE",
+  )!
+  const boundarySegments = boundaryOutline.map(
+    (point, index) =>
+      [
+        point,
+        boundaryOutline[(index + 1) % boundaryOutline.length]!,
+      ] as Segment,
+  )
+  const bounds = getComponentBounds(edgeComponent)
+  const corners = [
+    { x: bounds.minX, y: bounds.minY },
+    { x: bounds.minX, y: bounds.maxY },
+    { x: bounds.maxX, y: bounds.minY },
+    { x: bounds.maxX, y: bounds.maxY },
+  ]
+  expect(
+    corners.every(
+      (corner) => pointInOutline(corner, boundarySegments) !== "outside",
+    ),
+  ).toBe(true)
+  expect(
+    corners.some(
+      (corner) => pointInOutline(corner, boundarySegments) === "boundary",
+    ),
+  ).toBe(true)
+
+  const packOutput: PackOutput = {
+    ...packInput,
+    components: solver.packedComponents,
+  }
+  const graphics = getGraphicsFromPackOutput(packOutput)
+
+  expect(
+    getSvgFromGraphicsObject(graphics, {
+      backgroundColor: "white",
+    }),
+  ).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary

- Add `mustBeOnBoundary` to packing components
- Place constrained components inside and touching the board boundary
- Support clockwise, counter-clockwise, and angled board outlines
- Preserve the constraint when converting `PackOutput` back to `PackInput`
- Add an SVG snapshot regression test

## Test Plan

- `bun test --timeout 15000`
- `bun run format:check`

All tests pass: 122 passed, 10 skipped.