### PR TITLE
Fix packing obstacle generation rotated pill plated holes with rectangular pads

### DIFF
--- a/lib/plumbing/extractPadInfos.ts
+++ b/lib/plumbing/extractPadInfos.ts
@@ -154,6 +154,22 @@ export const extractPadInfos = (
         })
         break
       }
+      case "rotated_pill_hole_with_rect_pad": {
+        const size = getRotatedBoundingBoxSize({
+          width: ph.rect_pad_width,
+          height: ph.rect_pad_height,
+          ccwRotationDegrees: ph.rect_ccw_rotation,
+        })
+        pushPad({
+          padId: ph.pcb_plated_hole_id,
+          pcbPortId: ph.pcb_port_id,
+          sx: size.width,
+          sy: size.height,
+          x: ph.x,
+          y: ph.y,
+        })
+        break
+      }
       default: {
         console.warn(`Unsupported plated hole shape ${(ph as any).shape}`)
         break

--- a/lib/plumbing/getObstacleFromElement.ts
+++ b/lib/plumbing/getObstacleFromElement.ts
@@ -1,6 +1,20 @@
 import type { AnyCircuitElement } from "circuit-json"
 import type { InputObstacle } from "../types"
 
+const getRotatedRectBounds = (
+  width: number,
+  height: number,
+  ccwRotationDegrees: number,
+) => {
+  const angleRad = (ccwRotationDegrees * Math.PI) / 180
+  const absCos = Math.abs(Math.cos(angleRad))
+  const absSin = Math.abs(Math.sin(angleRad))
+  return {
+    width: width * absCos + height * absSin,
+    height: width * absSin + height * absCos,
+  }
+}
+
 /**
  * Convert a board-level circuit element into an InputObstacle, or return
  * undefined if the element type is not a recognised obstacle source.
@@ -18,6 +32,24 @@ export const getObstacleFromElement = (
       absoluteCenter: { x, y },
       width: rect_pad_width,
       height: rect_pad_height,
+    }
+  }
+
+  if (
+    element.type === "pcb_plated_hole" &&
+    element.shape === "rotated_pill_hole_with_rect_pad"
+  ) {
+    const { rect_pad_height, rect_pad_width, rect_ccw_rotation, x, y } = element
+    const bounds = getRotatedRectBounds(
+      rect_pad_width,
+      rect_pad_height,
+      rect_ccw_rotation,
+    )
+    return {
+      obstacleId: element.pcb_plated_hole_id,
+      absoluteCenter: { x, y },
+      width: bounds.width,
+      height: bounds.height,
     }
   }
 

--- a/tests/circuit-json-pack-conversion/pcb-hole-obstacles.test.ts
+++ b/tests/circuit-json-pack-conversion/pcb-hole-obstacles.test.ts
@@ -151,6 +151,41 @@ test("multiple pcb_holes are all added as obstacles", () => {
   expect(holeObstacles).toHaveLength(3)
 })
 
+test("rotated pill plated hole with rect pad is added as an obstacle", () => {
+  const circuitJson = makeCircuitJson([
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "pcb_plated_hole_rotated",
+      shape: "rotated_pill_hole_with_rect_pad",
+      hole_shape: "rotated_pill",
+      pad_shape: "rect",
+      hole_width: 4,
+      hole_height: 2,
+      hole_ccw_rotation: 30,
+      rect_pad_width: 6,
+      rect_pad_height: 4,
+      rect_ccw_rotation: 30,
+      hole_offset_x: 0,
+      hole_offset_y: 0,
+      x: 3,
+      y: -2,
+      layers: ["top", "bottom"],
+    },
+  ])
+
+  const packOutput = convertCircuitJsonToPackOutput(circuitJson, {
+    source_group_id: "source_group_0",
+  })
+
+  const obstacle = packOutput.obstacles!.find(
+    ({ obstacleId }) => obstacleId === "pcb_plated_hole_rotated",
+  )
+  expect(obstacle).toBeDefined()
+  expect(obstacle?.absoluteCenter).toEqual({ x: 3, y: -2 })
+  expect(obstacle?.width).toBeCloseTo(3 * Math.sqrt(3) + 2)
+  expect(obstacle?.height).toBeCloseTo(3 + 2 * Math.sqrt(3))
+})
+
 test("pcb_hole obstacles svg snapshot", async () => {
   const circuitJson = makeCircuitJson([
     {

--- a/tests/extractPadInfos-circle.test.ts
+++ b/tests/extractPadInfos-circle.test.ts
@@ -52,6 +52,52 @@ test("extractPadInfos handles circle plated hole", () => {
   expect(warnings).toHaveLength(0)
 })
 
+test("extractPadInfos handles rotated pill hole with rect pad", () => {
+  const soup = [
+    {
+      type: "pcb_component",
+      pcb_component_id: "comp1",
+      source_component_id: "src1",
+      center: { x: 0, y: 0 },
+      layer: "top",
+      rotation: 0,
+      width: 0,
+      height: 0,
+    },
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "hole1",
+      pcb_component_id: "comp1",
+      pcb_port_id: "port1",
+      shape: "rotated_pill_hole_with_rect_pad",
+      hole_shape: "rotated_pill",
+      pad_shape: "rect",
+      hole_width: 4,
+      hole_height: 2,
+      hole_ccw_rotation: 30,
+      rect_pad_width: 6,
+      rect_pad_height: 4,
+      rect_ccw_rotation: 30,
+      hole_offset_x: 0,
+      hole_offset_y: 0,
+      x: 3,
+      y: -2,
+      layers: ["top", "bottom"],
+    },
+  ]
+
+  const db = cju(soup as any)
+  const pcbComponent = soup[0] as unknown as PcbComponent
+  const pads = extractPadInfos(pcbComponent, db, (id) => id ?? "")
+
+  expect(pads).toHaveLength(1)
+  expect(pads[0]?.padId).toBe("hole1")
+  expect(pads[0]?.networkId).toBe("port1")
+  expect(pads[0]?.absoluteCenter).toEqual({ x: 3, y: -2 })
+  expect(pads[0]?.size.x).toBeCloseTo(3 * Math.sqrt(3) + 2)
+  expect(pads[0]?.size.y).toBeCloseTo(3 + 2 * Math.sqrt(3))
+})
+
 test("extractPadInfos handles pcb vias as pads", () => {
   const soup = [
     {


### PR DESCRIPTION
## Motivation

Rotated pill plated holes with rectangular pads were missing during pad extraction and obstacle generation. This could cause incorrect packing because their occupied board area was not considered, potentially allowing components to overlap them.

## Summary

- support `rotated_pill_hole_with_rect_pad` during pad extraction
- include these plated holes as packing obstacles
- calculate axis-aligned bounds based on rectangular pad rotation
- add tests for pad extraction and obstacle conversion

## Test plan

- verify rotated rectangular pad dimensions are calculated correctly
- verify plated holes are included in packing obstacles
- run the test suite