### PR TITLE
Add large weighted-connections packing repro

### DIFF
--- a/tests/repros/repro-large-weighted-connections.test.ts
+++ b/tests/repros/repro-large-weighted-connections.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { PackSolver2 } from "../../lib/PackSolver2/PackSolver2"
+import type { PackInput } from "../../lib/types"
+import packInputJson from "./repro-large-weighted-connections/pack-input.json"
+
+const packInput = packInputJson as PackInput
+
+test("repro-large-weighted-connections - captured input shape", () => {
+  expect(packInput.components).toHaveLength(218)
+  expect(
+    packInput.components.reduce(
+      (padCount, component) => padCount + component.pads.length,
+      0,
+    ),
+  ).toBe(1767)
+  expect(packInput.weightedConnections).toHaveLength(670)
+})
+
+const performanceReproTest =
+  process.env.RUN_SLOW_PACKING_REPRO === "1" ? test : test.skip
+
+// Exact PackInput captured at @tscircuit/core's PackSolver2 boundary for the
+// adjacent circuit.tsx, a 218-component board with 825 explicit traces. This is
+// intentionally opt-in because the current solver takes a very long time as the
+// placed-component outline and pairwise weighted connection searches grow. Run
+// with:
+//
+//   RUN_SLOW_PACKING_REPRO=1 bun test \
+//     tests/repros/repro-large-weighted-connections.test.ts
+performanceReproTest(
+  "repro-large-weighted-connections - PackSolver2 completes the captured board",
+  () => {
+    const solver = new PackSolver2(packInput)
+
+    solver.solve()
+
+    expect(solver.failed).toBe(false)
+    expect(solver.packedComponents).toHaveLength(packInput.components.length)
+  },
+)

--- a/tests/repros/repro-large-weighted-connections/circuit.tsx
+++ b/tests/repros/repro-large-weighted-connections/circuit.tsx
@@ -1,0 +1,3326 @@
+// @ts-nocheck -- captured against a newer tscircuit version than this repo uses
+export default () => (
+  <board width="220mm" height="150mm" schematicDisabled>
+    {/* soc */}
+    <chip
+      name="soc_U1"
+      footprint="bga529"
+      pinLabels={{
+        pin1: "VDD_ARM_1",
+        pin2: "VDD_ARM_2",
+        pin3: "VDD_ARM_3",
+        pin4: "VDD_SOC_1",
+        pin5: "VDD_SOC_2",
+        pin6: "VDD_SOC_3",
+        pin7: "VDD_DRAM_1",
+        pin8: "VDD_DRAM_2",
+        pin9: "VDD_DRAM_3",
+        pin10: "VDD_1V8_1",
+        pin11: "VDD_1V8_2",
+        pin12: "VDD_1V8_3",
+        pin13: "VDD_3V3_1",
+        pin14: "VDD_3V3_2",
+        pin15: "VDD_3V3_3",
+        pin16: "GND_1",
+        pin17: "GND_2",
+        pin18: "GND_3",
+        pin19: "GND_4",
+        pin20: "GND_5",
+        pin21: "DDR_DQ0",
+        pin22: "DDR_DQ1",
+        pin23: "DDR_DQ2",
+        pin24: "DDR_DQ3",
+        pin25: "DDR_DQ4",
+        pin26: "DDR_DQ5",
+        pin27: "DDR_DQ6",
+        pin28: "DDR_DQ7",
+        pin29: "DDR_DQ8",
+        pin30: "DDR_DQ9",
+        pin31: "DDR_DQ10",
+        pin32: "DDR_DQ11",
+        pin33: "DDR_DQ12",
+        pin34: "DDR_DQ13",
+        pin35: "DDR_DQ14",
+        pin36: "DDR_DQ15",
+        pin37: "DDR_A0",
+        pin38: "DDR_A1",
+        pin39: "DDR_A2",
+        pin40: "DDR_A3",
+        pin41: "DDR_A4",
+        pin42: "DDR_A5",
+        pin43: "DDR_A6",
+        pin44: "DDR_A7",
+        pin45: "DDR_A8",
+        pin46: "DDR_A9",
+        pin47: "DDR_CK_P",
+        pin48: "DDR_CK_N",
+        pin49: "DDR_CKE",
+        pin50: "DDR_CS_N",
+        pin51: "DDR_RAS_N",
+        pin52: "DDR_CAS_N",
+        pin53: "DDR_WE_N",
+        pin54: "EMMC_CLK",
+        pin55: "EMMC_CMD",
+        pin56: "EMMC_RESET_N",
+        pin57: "EMMC_DAT0",
+        pin58: "EMMC_DAT1",
+        pin59: "EMMC_DAT2",
+        pin60: "EMMC_DAT3",
+        pin61: "EMMC_DAT4",
+        pin62: "EMMC_DAT5",
+        pin63: "EMMC_DAT6",
+        pin64: "EMMC_DAT7",
+        pin65: "RGMII_TXC",
+        pin66: "RGMII_TXCTL",
+        pin67: "RGMII_RXC",
+        pin68: "RGMII_RXCTL",
+        pin69: "RGMII_TXD0",
+        pin70: "RGMII_TXD1",
+        pin71: "RGMII_TXD2",
+        pin72: "RGMII_TXD3",
+        pin73: "RGMII_RXD0",
+        pin74: "RGMII_RXD1",
+        pin75: "RGMII_RXD2",
+        pin76: "RGMII_RXD3",
+        pin77: "I2C1_SCL",
+        pin78: "I2C1_SDA",
+        pin79: "UART1_TXD",
+        pin80: "UART1_RXD",
+        pin81: "SOC_RESET_N",
+        pin82: "PWRON",
+        pin83: "BOOT_MODE0",
+        pin84: "BOOT_MODE1",
+        pin85: "JTAG_TCK",
+        pin86: "JTAG_TMS",
+        pin87: "JTAG_TDI",
+        pin88: "JTAG_TDO",
+        pin89: "USB1_DP",
+        pin90: "USB1_DN",
+        pin91: "HDMI_TX0_P",
+        pin92: "HDMI_TX0_N",
+        pin93: "SAI_MCLK",
+        pin94: "SAI_BCLK",
+        pin95: "SAI_LRCLK",
+        pin96: "SAI_TXD",
+        pin97: "SAI_RXD",
+        pin98: "XTAL_24M_IN",
+        pin99: "XTAL_24M_OUT",
+      }}
+      connections={{
+        pin1: "net.VDD_ARM_0V85",
+        pin2: "net.VDD_ARM_0V85",
+        pin3: "net.VDD_ARM_0V85",
+        pin4: "net.VDD_SOC_0V85",
+        pin5: "net.VDD_SOC_0V85",
+        pin6: "net.VDD_SOC_0V85",
+        pin7: "net.VDD_DRAM_1V1",
+        pin8: "net.VDD_DRAM_1V1",
+        pin9: "net.VDD_DRAM_1V1",
+        pin10: "net.VDD_1V8",
+        pin11: "net.VDD_1V8",
+        pin12: "net.VDD_1V8",
+        pin13: "net.VDD_3V3",
+        pin14: "net.VDD_3V3",
+        pin15: "net.VDD_3V3",
+        pin16: "net.GND",
+        pin17: "net.GND",
+        pin18: "net.GND",
+        pin19: "net.GND",
+        pin20: "net.GND",
+        pin21: "net.DDR_DQ0",
+        pin22: "net.DDR_DQ1",
+        pin23: "net.DDR_DQ2",
+        pin24: "net.DDR_DQ3",
+        pin25: "net.DDR_DQ4",
+        pin26: "net.DDR_DQ5",
+        pin27: "net.DDR_DQ6",
+        pin28: "net.DDR_DQ7",
+        pin29: "net.DDR_DQ8",
+        pin30: "net.DDR_DQ9",
+        pin31: "net.DDR_DQ10",
+        pin32: "net.DDR_DQ11",
+        pin33: "net.DDR_DQ12",
+        pin34: "net.DDR_DQ13",
+        pin35: "net.DDR_DQ14",
+        pin36: "net.DDR_DQ15",
+        pin37: "net.DDR_A0",
+        pin38: "net.DDR_A1",
+        pin39: "net.DDR_A2",
+        pin40: "net.DDR_A3",
+        pin41: "net.DDR_A4",
+        pin42: "net.DDR_A5",
+        pin43: "net.DDR_A6",
+        pin44: "net.DDR_A7",
+        pin45: "net.DDR_A8",
+        pin46: "net.DDR_A9",
+        pin47: "net.DDR_CK_P",
+        pin48: "net.DDR_CK_N",
+        pin49: "net.DDR_CKE",
+        pin50: "net.DDR_CS_N",
+        pin51: "net.DDR_RAS_N",
+        pin52: "net.DDR_CAS_N",
+        pin53: "net.DDR_WE_N",
+        pin54: "net.EMMC_CLK",
+        pin55: "net.EMMC_CMD",
+        pin56: "net.EMMC_RESET_N",
+        pin57: "net.EMMC_DAT0",
+        pin58: "net.EMMC_DAT1",
+        pin59: "net.EMMC_DAT2",
+        pin60: "net.EMMC_DAT3",
+        pin61: "net.EMMC_DAT4",
+        pin62: "net.EMMC_DAT5",
+        pin63: "net.EMMC_DAT6",
+        pin64: "net.EMMC_DAT7",
+        pin65: "net.RGMII_TXC",
+        pin66: "net.RGMII_TXCTL",
+        pin67: "net.RGMII_RXC",
+        pin68: "net.RGMII_RXCTL",
+        pin69: "net.RGMII_TXD0",
+        pin70: "net.RGMII_TXD1",
+        pin71: "net.RGMII_TXD2",
+        pin72: "net.RGMII_TXD3",
+        pin73: "net.RGMII_RXD0",
+        pin74: "net.RGMII_RXD1",
+        pin75: "net.RGMII_RXD2",
+        pin76: "net.RGMII_RXD3",
+        pin77: "net.I2C1_SCL",
+        pin78: "net.I2C1_SDA",
+        pin79: "net.UART1_TXD",
+        pin80: "net.UART1_RXD",
+        pin81: "net.SOC_RESET_N",
+        pin82: "net.PWRON",
+        pin83: "net.BOOT_MODE0",
+        pin84: "net.BOOT_MODE1",
+        pin85: "net.JTAG_TCK",
+        pin86: "net.JTAG_TMS",
+        pin87: "net.JTAG_TDI",
+        pin88: "net.JTAG_TDO",
+        pin89: "net.USB1_DP",
+        pin90: "net.USB1_DN",
+        pin91: "net.HDMI_TX0_P",
+        pin92: "net.HDMI_TX0_N",
+        pin93: "net.SAI_MCLK",
+        pin94: "net.SAI_BCLK",
+        pin95: "net.SAI_LRCLK",
+        pin96: "net.SAI_TXD",
+        pin97: "net.SAI_RXD",
+        pin98: "net.XTAL_24M_IN",
+        pin99: "net.XTAL_24M_OUT",
+      }}
+    />
+
+    {/* socdecoup */}
+    <capacitor
+      name="socdecoup_C1"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_ARM_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C2"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_ARM_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C3"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_ARM_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C4"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_ARM_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C5"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_ARM_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C6"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_ARM_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C7"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{ pin1: "net.VDD_ARM_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C8"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{ pin1: "net.VDD_ARM_0V85", pin2: "net.GND" }}
+    />
+
+    <capacitor
+      name="socdecoup_C9"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_SOC_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C10"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_SOC_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C11"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_SOC_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C12"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_SOC_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C13"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_SOC_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C14"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_SOC_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C15"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{ pin1: "net.VDD_SOC_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C16"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{ pin1: "net.VDD_SOC_0V85", pin2: "net.GND" }}
+    />
+
+    <capacitor
+      name="socdecoup_C17"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_DRAM_1V1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C18"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_DRAM_1V1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C19"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_DRAM_1V1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C20"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_DRAM_1V1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C21"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_DRAM_1V1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C22"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_DRAM_1V1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C23"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_DRAM_1V1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C24"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_DRAM_1V1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C25"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{ pin1: "net.VDD_DRAM_1V1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C26"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{ pin1: "net.VDD_DRAM_1V1", pin2: "net.GND" }}
+    />
+
+    <capacitor
+      name="socdecoup_C27"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C28"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C29"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C30"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C31"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C32"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C33"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C34"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+
+    <capacitor
+      name="socdecoup_C35"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C36"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C37"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C38"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C39"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="socdecoup_C40"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.GND" }}
+    />
+
+    {/* xtal24 */}
+    <crystal
+      name="xtal24_Y1"
+      frequency="24MHz"
+      loadCapacitance="12pF"
+      footprint="hc49"
+      connections={{
+        pin1: "net.XTAL_24M_IN",
+        pin2: "net.XTAL_24M_OUT",
+      }}
+    />
+    <capacitor
+      name="xtal24_C1"
+      capacitance="12pF"
+      footprint="0402"
+      connections={{
+        pin1: "net.XTAL_24M_IN",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="xtal24_C2"
+      capacitance="12pF"
+      footprint="0402"
+      connections={{
+        pin1: "net.XTAL_24M_OUT",
+        pin2: "net.GND",
+      }}
+    />
+
+    {/* rtcxtal */}
+    <crystal
+      name="rtcxtal_Y1"
+      footprint="hc49"
+      frequency="32.768kHz"
+      loadCapacitance="12pF"
+      connections={{
+        pin1: "net.XTAL_32K_IN",
+        pin2: "net.XTAL_32K_OUT",
+      }}
+    />
+    <capacitor
+      name="rtcxtal_C1"
+      footprint="0402"
+      capacitance="12pF"
+      connections={{
+        pin1: "net.XTAL_32K_IN",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="rtcxtal_C2"
+      footprint="0402"
+      capacitance="12pF"
+      connections={{
+        pin1: "net.XTAL_32K_OUT",
+        pin2: "net.GND",
+      }}
+    />
+
+    {/* ddr */}
+    <chip
+      name="ddr_U1"
+      footprint="bga200"
+      manufacturerPartNumber="MT53E1G16D16GBx16LPDDR4"
+      pinLabels={{
+        "1": "DQ0",
+        "2": "DQ1",
+        "3": "DQ2",
+        "4": "DQ3",
+        "5": "DQ4",
+        "6": "DQ5",
+        "7": "DQ6",
+        "8": "DQ7",
+        "9": "DQ8",
+        "10": "DQ9",
+        "11": "DQ10",
+        "12": "DQ11",
+        "13": "DQ12",
+        "14": "DQ13",
+        "15": "DQ14",
+        "16": "DQ15",
+        "17": "A0",
+        "18": "A1",
+        "19": "A2",
+        "20": "A3",
+        "21": "A4",
+        "22": "A5",
+        "23": "A6",
+        "24": "A7",
+        "25": "A8",
+        "26": "A9",
+        "27": "CK_P",
+        "28": "CK_N",
+        "29": "CKE",
+        "30": "CS_N",
+        "31": "RAS_N",
+        "32": "CAS_N",
+        "33": "WE_N",
+        "34": "VDD2_1",
+        "35": "VDD2_2",
+        "36": "VDD2_3",
+        "37": "VDDQ_1",
+        "38": "VDDQ_2",
+        "39": "VDDQ_3",
+        "40": "VSS_1",
+        "41": "VSS_2",
+        "42": "VSS_3",
+        "43": "VSS_4",
+        "44": "VSS_5",
+      }}
+      connections={{
+        DQ0: "net.DDR_DQ0",
+        DQ1: "net.DDR_DQ1",
+        DQ2: "net.DDR_DQ2",
+        DQ3: "net.DDR_DQ3",
+        DQ4: "net.DDR_DQ4",
+        DQ5: "net.DDR_DQ5",
+        DQ6: "net.DDR_DQ6",
+        DQ7: "net.DDR_DQ7",
+        DQ8: "net.DDR_DQ8",
+        DQ9: "net.DDR_DQ9",
+        DQ10: "net.DDR_DQ10",
+        DQ11: "net.DDR_DQ11",
+        DQ12: "net.DDR_DQ12",
+        DQ13: "net.DDR_DQ13",
+        DQ14: "net.DDR_DQ14",
+        DQ15: "net.DDR_DQ15",
+        A0: "net.DDR_A0",
+        A1: "net.DDR_A1",
+        A2: "net.DDR_A2",
+        A3: "net.DDR_A3",
+        A4: "net.DDR_A4",
+        A5: "net.DDR_A5",
+        A6: "net.DDR_A6",
+        A7: "net.DDR_A7",
+        A8: "net.DDR_A8",
+        A9: "net.DDR_A9",
+        CK_P: "net.DDR_CK_P",
+        CK_N: "net.DDR_CK_N",
+        CKE: "net.DDR_CKE",
+        CS_N: "net.DDR_CS_N",
+        RAS_N: "net.DDR_RAS_N",
+        CAS_N: "net.DDR_CAS_N",
+        WE_N: "net.DDR_WE_N",
+        VDD2_1: "net.VDD_DRAM_1V1",
+        VDD2_2: "net.VDD_DRAM_1V1",
+        VDD2_3: "net.VDD_DRAM_1V1",
+        VDDQ_1: "net.VDD_DRAM_0V6",
+        VDDQ_2: "net.VDD_DRAM_0V6",
+        VDDQ_3: "net.VDD_DRAM_0V6",
+        VSS_1: "net.GND",
+        VSS_2: "net.GND",
+        VSS_3: "net.GND",
+        VSS_4: "net.GND",
+        VSS_5: "net.GND",
+      }}
+    />
+
+    {/* ddrterm */}
+    <resistor
+      name="ddrterm_R1"
+      footprint="0402"
+      resistance="10k"
+      tolerance="1%"
+      connections={{
+        pin1: "net.VDD_DRAM_1V1",
+        pin2: "net.DDR_VREF",
+      }}
+    />
+    <resistor
+      name="ddrterm_R2"
+      footprint="0402"
+      resistance="12k"
+      tolerance="1%"
+      connections={{
+        pin1: "net.DDR_VREF",
+        pin2: "net.GND",
+      }}
+    />
+    <resistor
+      name="ddrterm_R3"
+      footprint="0402"
+      resistance="240"
+      tolerance="1%"
+      connections={{
+        pin1: "net.VDD_DRAM_0V6",
+        pin2: "net.GND",
+      }}
+    />
+
+    {/* ddrdecoup */}
+    <capacitor
+      name="ddrdecoup_C1"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_DRAM_1V1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="ddrdecoup_C2"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_DRAM_1V1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="ddrdecoup_C3"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{ pin1: "net.VDD_DRAM_1V1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="ddrdecoup_C4"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_DRAM_0V6", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="ddrdecoup_C5"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_DRAM_0V6", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="ddrdecoup_C6"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{ pin1: "net.VDD_DRAM_0V6", pin2: "net.GND" }}
+    />
+
+    {/* emmc */}
+    {/* <chip
+        name="emmc_U1" 
+        footprint="bga153"
+        connections={{
+          ...Object.fromEntries(
+            Array.from({ length: 153 }, (_, index) => [`pin${index + 1}`, "net.GND"]),
+          ),
+          pin1: "net.VDD_3V3",
+          pin2: "net.VDD_1V8",
+          pin3: "net.EMMC_CLK",
+          pin4: "net.EMMC_CMD",
+          pin5: "net.EMMC_RESET_N",
+          pin6: "net.EMMC_DAT0",
+          pin7: "net.EMMC_DAT1",
+          pin8: "net.EMMC_DAT2",
+          pin9: "net.EMMC_DAT3",
+          pin10: "net.EMMC_DAT4",
+          pin11: "net.EMMC_DAT5",
+          pin12: "net.EMMC_DAT6",
+          pin13: "net.EMMC_DAT7",
+        }}
+      /> */}
+
+    {/* pmic */}
+    <chip
+      name="pmic_U1"
+      footprint="qfn68"
+      connections={{
+        pin1: "net.SYS_5V",
+        pin2: "net.SYS_5V",
+        pin3: "net.SYS_5V",
+        pin4: "net.GND",
+        pin5: "net.GND",
+        pin6: "net.GND",
+        pin7: "net.pmic_PMIC_BUCK_ARM_SW",
+        pin8: "net.pmic_PMIC_BUCK_ARM_SW",
+        pin9: "net.pmic_PMIC_BUCK_SOC_SW",
+        pin10: "net.pmic_PMIC_BUCK_SOC_SW",
+        pin11: "net.pmic_PMIC_BUCK_DRAM_SW",
+        pin12: "net.pmic_PMIC_BUCK_DRAM_SW",
+        pin13: "net.pmic_PMIC_BUCK_1V8_SW",
+        pin14: "net.pmic_PMIC_BUCK_1V8_SW",
+        pin15: "net.pmic_PMIC_BUCK_3V3_SW",
+        pin16: "net.pmic_PMIC_BUCK_3V3_SW",
+        pin17: "net.VDD_ARM_0V85",
+        pin18: "net.VDD_SOC_0V85",
+        pin19: "net.VDD_DRAM_1V1",
+        pin20: "net.VDD_1V8",
+        pin21: "net.VDD_3V3",
+        pin22: "net.GND",
+        pin23: "net.GND",
+        pin24: "net.GND",
+        pin25: "net.GND",
+        pin26: "net.GND",
+        pin27: "net.GND",
+        pin28: "net.GND",
+        pin29: "net.GND",
+        pin30: "net.GND",
+        pin31: "net.GND",
+        pin32: "net.GND",
+        pin33: "net.GND",
+        pin34: "net.GND",
+        pin35: "net.I2C1_SCL",
+        pin36: "net.I2C1_SDA",
+        pin37: "net.PMIC_IRQ",
+        pin38: "net.PMIC_PG",
+        pin39: "net.PWRON",
+        pin40: "net.VDD_3V3",
+        pin41: "net.VDD_1V8",
+        pin42: "net.GND",
+        pin43: "net.GND",
+        pin44: "net.GND",
+        pin45: "net.GND",
+        pin46: "net.GND",
+        pin47: "net.GND",
+        pin48: "net.GND",
+        pin49: "net.GND",
+        pin50: "net.GND",
+        pin51: "net.GND",
+        pin52: "net.GND",
+        pin53: "net.GND",
+        pin54: "net.GND",
+        pin55: "net.GND",
+        pin56: "net.GND",
+        pin57: "net.GND",
+        pin58: "net.GND",
+        pin59: "net.GND",
+        pin60: "net.GND",
+        pin61: "net.GND",
+        pin62: "net.GND",
+        pin63: "net.GND",
+        pin64: "net.GND",
+        pin65: "net.GND",
+        pin66: "net.GND",
+        pin67: "net.GND",
+        pin68: "net.GND",
+      }}
+    />
+
+    <capacitor
+      name="pmic_C1"
+      footprint="0805"
+      capacitance="10uF"
+      connections={{ pin1: "net.SYS_5V", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="pmic_C2"
+      footprint="0805"
+      capacitance="10uF"
+      connections={{ pin1: "net.SYS_5V", pin2: "net.GND" }}
+    />
+
+    <inductor
+      name="pmic_L1"
+      footprint="0805"
+      inductance="2.2uH"
+      connections={{
+        pin1: "net.pmic_PMIC_BUCK_ARM_SW",
+        pin2: "net.VDD_ARM_0V85",
+      }}
+    />
+    <capacitor
+      name="pmic_C3"
+      footprint="0805"
+      capacitance="22uF"
+      connections={{ pin1: "net.VDD_ARM_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="pmic_C4"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_ARM_0V85", pin2: "net.GND" }}
+    />
+
+    <inductor
+      name="pmic_L2"
+      footprint="0805"
+      inductance="2.2uH"
+      connections={{
+        pin1: "net.pmic_PMIC_BUCK_SOC_SW",
+        pin2: "net.VDD_SOC_0V85",
+      }}
+    />
+    <capacitor
+      name="pmic_C5"
+      footprint="0805"
+      capacitance="22uF"
+      connections={{ pin1: "net.VDD_SOC_0V85", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="pmic_C6"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_SOC_0V85", pin2: "net.GND" }}
+    />
+
+    <inductor
+      name="pmic_L3"
+      footprint="0805"
+      inductance="2.2uH"
+      connections={{
+        pin1: "net.pmic_PMIC_BUCK_DRAM_SW",
+        pin2: "net.VDD_DRAM_1V1",
+      }}
+    />
+    <capacitor
+      name="pmic_C7"
+      footprint="0805"
+      capacitance="22uF"
+      connections={{ pin1: "net.VDD_DRAM_1V1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="pmic_C8"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_DRAM_1V1", pin2: "net.GND" }}
+    />
+
+    <inductor
+      name="pmic_L4"
+      footprint="0805"
+      inductance="2.2uH"
+      connections={{ pin1: "net.pmic_PMIC_BUCK_1V8_SW", pin2: "net.VDD_1V8" }}
+    />
+    <capacitor
+      name="pmic_C9"
+      footprint="0805"
+      capacitance="22uF"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="pmic_C10"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+
+    <inductor
+      name="pmic_L5"
+      footprint="0805"
+      inductance="2.2uH"
+      connections={{ pin1: "net.pmic_PMIC_BUCK_3V3_SW", pin2: "net.VDD_3V3" }}
+    />
+    <capacitor
+      name="pmic_C11"
+      footprint="0805"
+      capacitance="22uF"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="pmic_C12"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.GND" }}
+    />
+
+    <resistor
+      name="pmic_R1"
+      footprint="0402"
+      resistance="2.2kΩ"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.I2C1_SCL" }}
+    />
+    <resistor
+      name="pmic_R2"
+      footprint="0402"
+      resistance="2.2kΩ"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.I2C1_SDA" }}
+    />
+    <resistor
+      name="pmic_R3"
+      footprint="0402"
+      resistance="4.7kΩ"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.PMIC_IRQ" }}
+    />
+    <resistor
+      name="pmic_R4"
+      footprint="0402"
+      resistance="4.7kΩ"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.PMIC_PG" }}
+    />
+    <resistor
+      name="pmic_R5"
+      footprint="0402"
+      resistance="100kΩ"
+      connections={{ pin1: "net.PWRON", pin2: "net.GND" }}
+    />
+
+    {/* usbcpd */}
+    <chip
+      name="usbcpd_J1"
+      footprint="qfn32"
+      pinLabels={{
+        pin1: "GND_A1",
+        pin2: "VBUS_A4",
+        pin3: "CC1",
+        pin4: "DP_A6",
+        pin5: "DN_A7",
+        pin6: "SBU1",
+        pin7: "VBUS_A9",
+        pin8: "GND_A12",
+        pin9: "GND_B1",
+        pin10: "VBUS_B4",
+        pin11: "CC2",
+        pin12: "DP_B6",
+        pin13: "DN_B7",
+        pin14: "SBU2",
+        pin15: "VBUS_B9",
+        pin16: "GND_B12",
+        pin17: "SHELL",
+      }}
+      connections={{
+        GND_A1: "net.GND",
+        VBUS_A4: "net.USB_VBUS",
+        CC1: "net.PD_CC1",
+        DP_A6: "net.USB1_DP",
+        DN_A7: "net.USB1_DN",
+        VBUS_A9: "net.USB_VBUS",
+        GND_A12: "net.GND",
+        GND_B1: "net.GND",
+        VBUS_B4: "net.USB_VBUS",
+        CC2: "net.PD_CC2",
+        DP_B6: "net.USB1_DP",
+        DN_B7: "net.USB1_DN",
+        VBUS_B9: "net.USB_VBUS",
+        GND_B12: "net.GND",
+        SHELL: "net.GND",
+      }}
+    />
+
+    <resistor
+      name="usbcpd_R1"
+      footprint="0402"
+      resistance="5.1k"
+      connections={{
+        pin1: "net.PD_CC1",
+        pin2: "net.GND",
+      }}
+    />
+
+    <resistor
+      name="usbcpd_R2"
+      footprint="0402"
+      resistance="5.1k"
+      connections={{
+        pin1: "net.PD_CC2",
+        pin2: "net.GND",
+      }}
+    />
+
+    <chip
+      name="usbcpd_U1"
+      footprint="qfn32"
+      pinLabels={{
+        pin1: "CC1",
+        pin2: "CC2",
+        pin3: "VBUS",
+        pin4: "GND",
+      }}
+      connections={{
+        CC1: "net.PD_CC1",
+        CC2: "net.PD_CC2",
+        VBUS: "net.USB_VBUS",
+        GND: "net.GND",
+      }}
+    />
+
+    <chip
+      name="usbcpd_U2"
+      footprint="sot23_5"
+      pinLabels={{
+        pin1: "USB_DP",
+        pin2: "USB_DN",
+        pin3: "CC1",
+        pin4: "CC2",
+        pin5: "GND",
+      }}
+      connections={{
+        USB_DP: "net.USB1_DP",
+        USB_DN: "net.USB1_DN",
+        CC1: "net.PD_CC1",
+        CC2: "net.PD_CC2",
+        GND: "net.GND",
+      }}
+    />
+
+    <chip
+      name="usbcpd_D1"
+      footprint="sod123"
+      pinLabels={{
+        pin1: "A",
+        pin2: "K",
+      }}
+      connections={{
+        A: "net.GND",
+        K: "net.USB_VBUS",
+      }}
+    />
+
+    {/* inprot */}
+    <chip
+      name="inprot_U1"
+      footprint="sot23_3"
+      connections={{
+        pin1: "net.inprot_PMOS_GATE",
+        pin2: "net.USB_VBUS",
+        pin3: "net.SYS_5V",
+      }}
+    />
+    <resistor
+      name="inprot_R1"
+      resistance="100k"
+      footprint="0402"
+      connections={{
+        pin1: "net.inprot_PMOS_GATE",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="inprot_C1"
+      capacitance="100nF"
+      footprint="0402"
+      connections={{
+        pin1: "net.USB_VBUS",
+        pin2: "net.inprot_PMOS_GATE",
+      }}
+    />
+
+    {/* buck33 */}
+    <chip
+      name="buck33_U1"
+      footprint="qfn16"
+      manufacturerPartNumber="TPS62130RGTR"
+      pinLabels={{
+        pin1: "SW",
+        pin2: "SW",
+        pin3: "PGND",
+        pin4: "PGND",
+        pin5: "AGND",
+        pin6: "FB",
+        pin7: "PG",
+        pin8: "EN",
+        pin9: "SS_TR",
+        pin10: "VOS",
+        pin11: "AVIN",
+        pin12: "VIN",
+        pin13: "VIN",
+        pin14: "NC",
+        pin15: "NC",
+        pin16: "NC",
+        pin17: "THERMAL_PAD",
+      }}
+      connections={{
+        pin1: "net.buck33_buck33_SW",
+        pin2: "net.buck33_buck33_SW",
+        pin3: "net.GND",
+        pin4: "net.GND",
+        pin5: "net.GND",
+        pin6: "net.buck33_buck33_FB",
+        pin8: "net.SYS_5V",
+        pin9: "net.buck33_buck33_SS",
+        pin10: "net.VDD_3V3",
+        pin11: "net.SYS_5V",
+        pin12: "net.SYS_5V",
+        pin13: "net.SYS_5V",
+      }}
+    />
+
+    <capacitor
+      name="buck33_C1"
+      footprint="0805"
+      capacitance="10uF"
+      maxVoltageRating="10V"
+      connections={{
+        pin1: "net.SYS_5V",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="buck33_C2"
+      footprint="0805"
+      capacitance="10uF"
+      maxVoltageRating="10V"
+      connections={{
+        pin1: "net.SYS_5V",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="buck33_C3"
+      footprint="0402"
+      capacitance="100nF"
+      maxVoltageRating="16V"
+      connections={{
+        pin1: "net.SYS_5V",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="buck33_C4"
+      footprint="0402"
+      capacitance="1uF"
+      maxVoltageRating="10V"
+      connections={{
+        pin1: "net.SYS_5V",
+        pin2: "net.GND",
+      }}
+    />
+
+    <inductor
+      name="buck33_L1"
+      footprint="1210"
+      inductance="1uH"
+      maxCurrentRating="4A"
+      connections={{
+        pin1: "net.buck33_buck33_SW",
+        pin2: "net.VDD_3V3",
+      }}
+    />
+
+    <capacitor
+      name="buck33_C5"
+      footprint="0805"
+      capacitance="22uF"
+      maxVoltageRating="6.3V"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="buck33_C6"
+      footprint="0805"
+      capacitance="22uF"
+      maxVoltageRating="6.3V"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.GND",
+      }}
+    />
+
+    <resistor
+      name="buck33_R1"
+      footprint="0402"
+      resistance="309k"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.buck33_buck33_FB",
+      }}
+    />
+    <resistor
+      name="buck33_R2"
+      footprint="0402"
+      resistance="100k"
+      connections={{
+        pin1: "net.buck33_buck33_FB",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="buck33_C7"
+      footprint="0402"
+      capacitance="22pF"
+      maxVoltageRating="16V"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.buck33_buck33_FB",
+      }}
+    />
+    <capacitor
+      name="buck33_C8"
+      footprint="0402"
+      capacitance="10nF"
+      maxVoltageRating="16V"
+      connections={{
+        pin1: "net.buck33_buck33_SS",
+        pin2: "net.GND",
+      }}
+    />
+
+    {/* buck18 */}
+    <chip
+      name="buck18_U1"
+      footprint="qfn16"
+      pinLabels={{
+        pin1: "SW",
+        pin2: "SW",
+        pin3: "PGND",
+        pin4: "PGND",
+        pin5: "VIN",
+        pin6: "VIN",
+        pin7: "EN",
+        pin8: "PG",
+        pin9: "AGND",
+        pin10: "FB",
+        pin11: "SS_TR",
+        pin12: "DEF",
+        pin13: "VOS",
+      }}
+      connections={{
+        pin1: "net.buck18_SW_NODE",
+        pin2: "net.buck18_SW_NODE",
+        pin3: "net.GND",
+        pin4: "net.GND",
+        pin5: "net.SYS_5V",
+        pin6: "net.SYS_5V",
+        pin7: "net.SYS_5V",
+        pin9: "net.GND",
+        pin10: "net.buck18_FB_DIVIDER",
+        pin11: "net.buck18_SOFTSTART",
+        pin12: "net.GND",
+        pin13: "net.VDD_1V8",
+      }}
+    />
+
+    <capacitor
+      name="buck18_C1"
+      footprint="0805"
+      capacitance="10uF"
+      connections={{ pin1: "net.SYS_5V", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="buck18_C2"
+      footprint="0805"
+      capacitance="10uF"
+      connections={{ pin1: "net.SYS_5V", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="buck18_C3"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.SYS_5V", pin2: "net.GND" }}
+    />
+
+    <inductor
+      name="buck18_L1"
+      footprint="0805"
+      inductance="2.2uH"
+      connections={{ pin1: "net.buck18_SW_NODE", pin2: "net.VDD_1V8" }}
+    />
+
+    <capacitor
+      name="buck18_C4"
+      footprint="0805"
+      capacitance="22uF"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="buck18_C5"
+      footprint="0805"
+      capacitance="22uF"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="buck18_C6"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+
+    <resistor
+      name="buck18_R1"
+      footprint="0402"
+      resistance="100k"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.buck18_FB_DIVIDER" }}
+    />
+    <resistor
+      name="buck18_R2"
+      footprint="0402"
+      resistance="80.6k"
+      connections={{ pin1: "net.buck18_FB_DIVIDER", pin2: "net.GND" }}
+    />
+
+    <capacitor
+      name="buck18_C7"
+      footprint="0402"
+      capacitance="4.7nF"
+      connections={{ pin1: "net.buck18_SOFTSTART", pin2: "net.GND" }}
+    />
+
+    {/* ldo06 */}
+    <chip
+      name="ldo06_U1"
+      footprint="sot23_5"
+      manufacturerPartNumber="TPS7A2006PDBVR"
+      connections={{
+        pin1: "net.VDD_1V8",
+        pin2: "net.GND",
+        pin3: "net.VDD_1V8",
+        pin5: "net.VDD_DRAM_0V6",
+      }}
+    />
+    <capacitor
+      name="ldo06_C1"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{
+        pin1: "net.VDD_1V8",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="ldo06_C2"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{
+        pin1: "net.VDD_DRAM_0V6",
+        pin2: "net.GND",
+      }}
+    />
+
+    {/* ldortc */}
+    <chip
+      name="ldortc_U1"
+      footprint="sot23_5"
+      manufacturerPartNumber="LP5907MFX-3.0/NOPB"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.GND",
+        pin3: "net.VDD_3V3",
+        pin5: "net.VDD_RTC_3V0",
+      }}
+    />
+    <capacitor
+      name="ldortc_C1"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="ldortc_C2"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{
+        pin1: "net.VDD_RTC_3V0",
+        pin2: "net.GND",
+      }}
+    />
+
+    {/* ldoaudio */}
+    <chip
+      name="ldoaudio_U1"
+      footprint="sot23_5"
+      manufacturerPartNumber="AP2112K-3.3TRG1"
+      pinLabels={{
+        pin1: "GND",
+        pin2: "VOUT",
+        pin3: "EN",
+        pin4: "NC",
+        pin5: "VIN",
+      }}
+      connections={{
+        pin1: "net.GND",
+        pin2: "net.VDD_AUDIO_3V3",
+        pin3: "net.VDD_3V3",
+        pin5: "net.VDD_3V3",
+      }}
+    />
+    <capacitor
+      name="ldoaudio_C1"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="ldoaudio_C2"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{
+        pin1: "net.VDD_AUDIO_3V3",
+        pin2: "net.GND",
+      }}
+    />
+
+    {/* ldohdmi */}
+    <chip
+      name="ldohdmi_U1"
+      footprint="sot23_5"
+      manufacturerPartNumber="TLV75518PDBVR"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.GND",
+        pin3: "net.VDD_3V3",
+        pin5: "net.VDD_HDMI_1V8",
+      }}
+    />
+    <capacitor
+      name="ldohdmi_C1"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="ldohdmi_C2"
+      footprint="0402"
+      capacitance="1uF"
+      connections={{
+        pin1: "net.VDD_HDMI_1V8",
+        pin2: "net.GND",
+      }}
+    />
+
+    {/* bulk */}
+    <capacitor
+      name="bulk_C1"
+      capacitance="10uF"
+      maxVoltageRating="16V"
+      footprint="0805"
+      connections={{ pin1: "net.SYS_5V", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="bulk_C2"
+      capacitance="10uF"
+      maxVoltageRating="16V"
+      footprint="0805"
+      connections={{ pin1: "net.SYS_5V", pin2: "net.GND" }}
+    />
+
+    {/* railcaps */}
+    <capacitor
+      name="railcaps_C1"
+      capacitance="47uF"
+      footprint="0805"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="railcaps_C2"
+      capacitance="10uF"
+      footprint="0805"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="railcaps_C3"
+      capacitance="1uF"
+      footprint="0402"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="railcaps_C4"
+      capacitance="100nF"
+      footprint="0402"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="railcaps_C5"
+      capacitance="100nF"
+      footprint="0402"
+      connections={{ pin1: "net.VDD_3V3", pin2: "net.GND" }}
+    />
+
+    <capacitor
+      name="railcaps_C6"
+      capacitance="22uF"
+      footprint="0805"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="railcaps_C7"
+      capacitance="10uF"
+      footprint="0805"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="railcaps_C8"
+      capacitance="1uF"
+      footprint="0402"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="railcaps_C9"
+      capacitance="100nF"
+      footprint="0402"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="railcaps_C10"
+      capacitance="100nF"
+      footprint="0402"
+      connections={{ pin1: "net.VDD_1V8", pin2: "net.GND" }}
+    />
+
+    {/* phy */}
+    <chip
+      name="phy_U1"
+      manufacturerPartNumber="RTL8211F-CG"
+      footprint="qfn48"
+      pinLabels={{
+        "1": "VDD33",
+        "2": "AVDD33",
+        "3": "VDDIO",
+        "4": "GND",
+        "5": "TXC",
+        "6": "TXCTL",
+        "7": "TXD0",
+        "8": "TXD1",
+        "9": "TXD2",
+        "10": "TXD3",
+        "11": "RXC",
+        "12": "RXCTL",
+        "13": "RXD0",
+        "14": "RXD1",
+        "15": "RXD2",
+        "16": "RXD3",
+        "17": "MDC",
+        "18": "MDIO",
+        "19": "RESET_N",
+        "20": "TXP",
+        "21": "TXN",
+        "22": "RXP",
+        "23": "RXN",
+        "24": "XI",
+        "25": "XO",
+      }}
+      connections={{
+        VDD33: "net.VDD_3V3",
+        AVDD33: "net.VDD_3V3",
+        VDDIO: "net.VDD_1V8",
+        GND: "net.GND",
+        TXC: "net.RGMII_TXC",
+        TXCTL: "net.RGMII_TXCTL",
+        TXD0: "net.RGMII_TXD0",
+        TXD1: "net.RGMII_TXD1",
+        TXD2: "net.RGMII_TXD2",
+        TXD3: "net.RGMII_TXD3",
+        RXC: "net.RGMII_RXC",
+        RXCTL: "net.RGMII_RXCTL",
+        RXD0: "net.RGMII_RXD0",
+        RXD1: "net.RGMII_RXD1",
+        RXD2: "net.RGMII_RXD2",
+        RXD3: "net.RGMII_RXD3",
+        MDC: "net.ENET_MDC",
+        MDIO: "net.ENET_MDIO",
+        RESET_N: "net.ENET_RESET_N",
+        TXP: "net.ETH_TXP",
+        TXN: "net.ETH_TXN",
+        RXP: "net.ETH_RXP",
+        RXN: "net.ETH_RXN",
+        XI: "net.ETH_XI",
+        XO: "net.ETH_XO",
+      }}
+    />
+
+    <resistor
+      name="phy_R1"
+      resistance="2.2k"
+      footprint="0402"
+      connections={{
+        pin1: "net.ENET_MDIO",
+        pin2: "net.VDD_1V8",
+      }}
+    />
+
+    <resistor
+      name="phy_R2"
+      resistance="10k"
+      footprint="0402"
+      connections={{
+        pin1: "net.ENET_RESET_N",
+        pin2: "net.VDD_1V8",
+      }}
+    />
+
+    <resistor
+      name="phy_R3"
+      resistance="10k"
+      footprint="0402"
+      connections={{
+        pin1: "net.RGMII_RXD0",
+        pin2: "net.VDD_1V8",
+      }}
+    />
+
+    <resistor
+      name="phy_R4"
+      resistance="10k"
+      footprint="0402"
+      connections={{
+        pin1: "net.RGMII_RXD1",
+        pin2: "net.GND",
+      }}
+    />
+
+    <resistor
+      name="phy_R5"
+      resistance="10k"
+      footprint="0402"
+      connections={{
+        pin1: "net.RGMII_RXD2",
+        pin2: "net.GND",
+      }}
+    />
+
+    {/* ethxtal */}
+    <crystal
+      name="ethxtal_Y1"
+      footprint="hc49"
+      frequency="25MHz"
+      loadCapacitance="18pF"
+      connections={{
+        pin1: "net.ETH_XI",
+        pin2: "net.ETH_XO",
+      }}
+    />
+    <capacitor
+      name="ethxtal_C1"
+      footprint="0402"
+      capacitance="18pF"
+      connections={{
+        pin1: "net.ETH_XI",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="ethxtal_C2"
+      footprint="0402"
+      capacitance="18pF"
+      connections={{
+        pin1: "net.ETH_XO",
+        pin2: "net.GND",
+      }}
+    />
+
+    {/* magjack */}
+    <chip
+      name="magjack_J1"
+      footprint="pinrow16"
+      pinLabels={{
+        pin1: "TXP",
+        pin2: "TXN",
+        pin3: "RXP",
+        pin4: "RXN",
+        pin5: "TX_CT",
+        pin6: "RX_CT",
+        pin7: "LED_LINK_A",
+        pin8: "LED_LINK_K",
+        pin9: "LED_ACT_A",
+        pin10: "LED_ACT_K",
+        pin11: "BS1",
+        pin12: "BS2",
+        pin13: "BS3",
+        pin14: "BS4",
+        pin15: "SHIELD",
+      }}
+      connections={{
+        pin1: "net.ETH_TXP",
+        pin2: "net.ETH_TXN",
+        pin3: "net.ETH_RXP",
+        pin4: "net.ETH_RXN",
+        pin5: "net.VDD_3V3",
+        pin6: "net.VDD_3V3",
+        pin7: "net.magjack_magjack_link_led_anode",
+        pin8: "net.LED_LINK",
+        pin9: "net.magjack_magjack_act_led_anode",
+        pin10: "net.LED_ACT",
+        pin11: "net.magjack_magjack_bob_smith_1",
+        pin12: "net.magjack_magjack_bob_smith_2",
+        pin13: "net.magjack_magjack_bob_smith_3",
+        pin14: "net.magjack_magjack_bob_smith_4",
+        pin15: "net.GND",
+      }}
+    />
+
+    <resistor
+      name="magjack_R1"
+      resistance="75ohm"
+      footprint="0402"
+      connections={{
+        pin1: "net.magjack_magjack_bob_smith_1",
+        pin2: "net.magjack_magjack_bob_smith_node",
+      }}
+    />
+    <resistor
+      name="magjack_R2"
+      resistance="75ohm"
+      footprint="0402"
+      connections={{
+        pin1: "net.magjack_magjack_bob_smith_2",
+        pin2: "net.magjack_magjack_bob_smith_node",
+      }}
+    />
+    <resistor
+      name="magjack_R3"
+      resistance="75ohm"
+      footprint="0402"
+      connections={{
+        pin1: "net.magjack_magjack_bob_smith_3",
+        pin2: "net.magjack_magjack_bob_smith_node",
+      }}
+    />
+    <resistor
+      name="magjack_R4"
+      resistance="75ohm"
+      footprint="0402"
+      connections={{
+        pin1: "net.magjack_magjack_bob_smith_4",
+        pin2: "net.magjack_magjack_bob_smith_node",
+      }}
+    />
+    <capacitor
+      name="magjack_C1"
+      capacitance="1nF"
+      footprint="0805"
+      connections={{
+        pin1: "net.magjack_magjack_bob_smith_node",
+        pin2: "net.GND",
+      }}
+    />
+
+    <resistor
+      name="magjack_R5"
+      resistance="1kohm"
+      footprint="0402"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.magjack_magjack_link_led_anode",
+      }}
+    />
+    <resistor
+      name="magjack_R6"
+      resistance="1kohm"
+      footprint="0402"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.magjack_magjack_act_led_anode",
+      }}
+    />
+
+    {/* hdmitx */}
+    <capacitor
+      name="hdmitx_C1"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.HDMI_TX2_P", pin2: "net.hdmitx_TMDS2_P_AC" }}
+    />
+    <capacitor
+      name="hdmitx_C2"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.HDMI_TX2_N", pin2: "net.hdmitx_TMDS2_N_AC" }}
+    />
+    <capacitor
+      name="hdmitx_C3"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.HDMI_TX1_P", pin2: "net.hdmitx_TMDS1_P_AC" }}
+    />
+    <capacitor
+      name="hdmitx_C4"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.HDMI_TX1_N", pin2: "net.hdmitx_TMDS1_N_AC" }}
+    />
+    <capacitor
+      name="hdmitx_C5"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.HDMI_TX0_P", pin2: "net.hdmitx_TMDS0_P_AC" }}
+    />
+    <capacitor
+      name="hdmitx_C6"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.HDMI_TX0_N", pin2: "net.hdmitx_TMDS0_N_AC" }}
+    />
+    <capacitor
+      name="hdmitx_C7"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.HDMI_CLK_P", pin2: "net.hdmitx_TMDSCLK_P_AC" }}
+    />
+    <capacitor
+      name="hdmitx_C8"
+      footprint="0402"
+      capacitance="100nF"
+      connections={{ pin1: "net.HDMI_CLK_N", pin2: "net.hdmitx_TMDSCLK_N_AC" }}
+    />
+
+    <diode
+      name="hdmitx_D1"
+      footprint="0402"
+      manufacturerPartNumber="ESD5V"
+      connections={{ anode: "net.hdmitx_TMDS2_P_AC", cathode: "net.GND" }}
+    />
+    <diode
+      name="hdmitx_D2"
+      footprint="0402"
+      manufacturerPartNumber="ESD5V"
+      connections={{ anode: "net.hdmitx_TMDS2_N_AC", cathode: "net.GND" }}
+    />
+    <diode
+      name="hdmitx_D3"
+      footprint="0402"
+      manufacturerPartNumber="ESD5V"
+      connections={{ anode: "net.hdmitx_TMDS1_P_AC", cathode: "net.GND" }}
+    />
+    <diode
+      name="hdmitx_D4"
+      footprint="0402"
+      manufacturerPartNumber="ESD5V"
+      connections={{ anode: "net.hdmitx_TMDS1_N_AC", cathode: "net.GND" }}
+    />
+    <diode
+      name="hdmitx_D5"
+      footprint="0402"
+      manufacturerPartNumber="ESD5V"
+      connections={{ anode: "net.hdmitx_TMDS0_P_AC", cathode: "net.GND" }}
+    />
+    <diode
+      name="hdmitx_D6"
+      footprint="0402"
+      manufacturerPartNumber="ESD5V"
+      connections={{ anode: "net.hdmitx_TMDS0_N_AC", cathode: "net.GND" }}
+    />
+    <diode
+      name="hdmitx_D7"
+      footprint="0402"
+      manufacturerPartNumber="ESD5V"
+      connections={{ anode: "net.hdmitx_TMDSCLK_P_AC", cathode: "net.GND" }}
+    />
+    <diode
+      name="hdmitx_D8"
+      footprint="0402"
+      manufacturerPartNumber="ESD5V"
+      connections={{ anode: "net.hdmitx_TMDSCLK_N_AC", cathode: "net.GND" }}
+    />
+    <diode
+      name="hdmitx_D9"
+      footprint="0402"
+      manufacturerPartNumber="ESD5V"
+      connections={{ anode: "net.I2C1_SCL", cathode: "net.GND" }}
+    />
+    <diode
+      name="hdmitx_D10"
+      footprint="0402"
+      manufacturerPartNumber="ESD5V"
+      connections={{ anode: "net.I2C1_SDA", cathode: "net.GND" }}
+    />
+
+    <connector
+      name="hdmitx_J1"
+      footprint="pinrow20"
+      connections={{
+        pin1: "net.hdmitx_TMDS2_P_AC",
+        pin2: "net.GND",
+        pin3: "net.hdmitx_TMDS2_N_AC",
+        pin4: "net.hdmitx_TMDS1_P_AC",
+        pin5: "net.GND",
+        pin6: "net.hdmitx_TMDS1_N_AC",
+        pin7: "net.hdmitx_TMDS0_P_AC",
+        pin8: "net.GND",
+        pin9: "net.hdmitx_TMDS0_N_AC",
+        pin10: "net.hdmitx_TMDSCLK_P_AC",
+        pin11: "net.GND",
+        pin12: "net.hdmitx_TMDSCLK_N_AC",
+        pin15: "net.I2C1_SCL",
+        pin16: "net.I2C1_SDA",
+        pin17: "net.GND",
+      }}
+    />
+
+    {/* hdmiconn */}
+    <chip
+      name="hdmiconn_J1"
+      footprint="pinrow20"
+      pinLabels={{
+        pin1: "1",
+        pin2: "2",
+        pin3: "3",
+        pin4: "4",
+        pin5: "5",
+        pin6: "6",
+        pin7: "7",
+        pin8: "8",
+        pin9: "9",
+        pin10: "10",
+        pin11: "11",
+        pin12: "12",
+        pin13: "13",
+        pin14: "14",
+        pin15: "15",
+        pin16: "16",
+        pin17: "17",
+        pin18: "18",
+        pin19: "19",
+      }}
+      connections={{
+        pin1: "net.HDMI_TX2_P",
+        pin2: "net.GND",
+        pin3: "net.HDMI_TX2_N",
+        pin4: "net.HDMI_TX1_P",
+        pin5: "net.GND",
+        pin6: "net.HDMI_TX1_N",
+        pin7: "net.HDMI_TX0_P",
+        pin8: "net.GND",
+        pin9: "net.HDMI_TX0_N",
+        pin10: "net.HDMI_CLK_P",
+        pin11: "net.GND",
+        pin12: "net.HDMI_CLK_N",
+        pin13: "net.hdmiconn_HDMI_CEC",
+        pin14: "net.hdmiconn_HDMI_HEAC",
+        pin15: "net.hdmiconn_HDMI_DDC_SCL",
+        pin16: "net.hdmiconn_HDMI_DDC_SDA",
+        pin17: "net.GND",
+        pin18: "net.SYS_5V",
+        pin19: "net.HDMI_HPD",
+      }}
+    />
+
+    <diode
+      name="hdmiconn_D1"
+      footprint="0402"
+      connections={{ pin1: "net.HDMI_TX2_P", pin2: "net.GND" }}
+    />
+    <diode
+      name="hdmiconn_D2"
+      footprint="0402"
+      connections={{ pin1: "net.HDMI_TX2_N", pin2: "net.GND" }}
+    />
+    <diode
+      name="hdmiconn_D3"
+      footprint="0402"
+      connections={{ pin1: "net.HDMI_TX1_P", pin2: "net.GND" }}
+    />
+    <diode
+      name="hdmiconn_D4"
+      footprint="0402"
+      connections={{ pin1: "net.HDMI_TX1_N", pin2: "net.GND" }}
+    />
+    <diode
+      name="hdmiconn_D5"
+      footprint="0402"
+      connections={{ pin1: "net.HDMI_TX0_P", pin2: "net.GND" }}
+    />
+    <diode
+      name="hdmiconn_D6"
+      footprint="0402"
+      connections={{ pin1: "net.HDMI_TX0_N", pin2: "net.GND" }}
+    />
+    <diode
+      name="hdmiconn_D7"
+      footprint="0402"
+      connections={{ pin1: "net.HDMI_CLK_P", pin2: "net.GND" }}
+    />
+    <diode
+      name="hdmiconn_D8"
+      footprint="0402"
+      connections={{ pin1: "net.HDMI_CLK_N", pin2: "net.GND" }}
+    />
+
+    {/* codec */}
+    <chip
+      name="codec_U1"
+      footprint="qfn32"
+      connections={{
+        pin1: "net.VDD_AUDIO_3V3",
+        pin2: "net.VDD_AUDIO_3V3",
+        pin3: "net.GND",
+        pin4: "net.SAI_MCLK",
+        pin5: "net.SAI_BCLK",
+        pin6: "net.SAI_LRCLK",
+        pin7: "net.SAI_TXD",
+        pin8: "net.SAI_RXD",
+        pin9: "net.I2C1_SCL",
+        pin10: "net.I2C1_SDA",
+        pin11: "net.CODEC_RESET_N",
+        pin12: "net.AUDIO_L",
+        pin13: "net.AUDIO_R",
+        pin14: "net.codec_codec_vmid",
+        pin15: "net.codec_codec_dcvdd_1v8",
+        pin16: "net.GND",
+        pin17: "net.GND",
+        pin18: "net.GND",
+        pin19: "net.GND",
+        pin20: "net.GND",
+        pin21: "net.codec_codec_chargepump_positive",
+        pin22: "net.codec_codec_chargepump_negative",
+        pin23: "net.VDD_AUDIO_3V3",
+        pin24: "net.GND",
+        pin25: "net.GND",
+        pin26: "net.GND",
+        pin27: "net.GND",
+        pin28: "net.GND",
+        pin29: "net.GND",
+        pin30: "net.GND",
+        pin31: "net.GND",
+        pin32: "net.GND",
+      }}
+    />
+
+    <resistor
+      name="codec_R1"
+      resistance="4.7k"
+      footprint="0402"
+      connections={{
+        pin1: "net.VDD_AUDIO_3V3",
+        pin2: "net.I2C1_SCL",
+      }}
+    />
+    <resistor
+      name="codec_R2"
+      resistance="4.7k"
+      footprint="0402"
+      connections={{
+        pin1: "net.VDD_AUDIO_3V3",
+        pin2: "net.I2C1_SDA",
+      }}
+    />
+    <resistor
+      name="codec_R3"
+      resistance="10k"
+      footprint="0402"
+      connections={{
+        pin1: "net.VDD_AUDIO_3V3",
+        pin2: "net.CODEC_RESET_N",
+      }}
+    />
+
+    <capacitor
+      name="codec_C1"
+      capacitance="100nF"
+      footprint="0402"
+      connections={{
+        pin1: "net.VDD_AUDIO_3V3",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="codec_C2"
+      capacitance="1uF"
+      footprint="0402"
+      connections={{
+        pin1: "net.VDD_AUDIO_3V3",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="codec_C3"
+      capacitance="100nF"
+      footprint="0402"
+      connections={{
+        pin1: "net.VDD_AUDIO_3V3",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="codec_C4"
+      capacitance="1uF"
+      footprint="0402"
+      connections={{
+        pin1: "net.codec_codec_dcvdd_1v8",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="codec_C5"
+      capacitance="4.7uF"
+      footprint="0402"
+      connections={{
+        pin1: "net.codec_codec_vmid",
+        pin2: "net.GND",
+      }}
+    />
+    <capacitor
+      name="codec_C6"
+      capacitance="1uF"
+      footprint="0402"
+      connections={{
+        pin1: "net.codec_codec_chargepump_positive",
+        pin2: "net.codec_codec_chargepump_negative",
+      }}
+    />
+
+    {/* audiojack */}
+    <capacitor
+      name="audiojack_C1"
+      footprint="0805"
+      capacitance="1uF"
+      connections={{
+        pin1: "net.AUDIO_L",
+        pin2: "net.audiojack_HEADPHONE_L",
+      }}
+    />
+    <capacitor
+      name="audiojack_C2"
+      footprint="0805"
+      capacitance="1uF"
+      connections={{
+        pin1: "net.AUDIO_R",
+        pin2: "net.audiojack_HEADPHONE_R",
+      }}
+    />
+    <chip
+      name="audiojack_J1"
+      footprint="pinrow3"
+      connections={{
+        pin1: "net.audiojack_HEADPHONE_L",
+        pin2: "net.audiojack_HEADPHONE_R",
+        pin3: "net.GND",
+      }}
+    />
+
+    {/* usbhost */}
+    <chip
+      name="usbhost_U1"
+      footprint="sot23_5"
+      pinLabels={{
+        pin1: "ILIM",
+        pin2: "GND",
+        pin3: "EN",
+        pin4: "IN",
+        pin5: "OUT",
+      }}
+      connections={{
+        pin1: "net.usbhost_usbhost_ILIM",
+        pin2: "net.GND",
+        pin3: "net.USB_VBUS_EN",
+        pin4: "net.SYS_5V",
+        pin5: "net.usbhost_usbhost_VBUS",
+      }}
+    />
+
+    <resistor
+      name="usbhost_R1"
+      footprint="0402"
+      resistance="49.9k"
+      connections={{
+        pin1: "net.usbhost_usbhost_ILIM",
+        pin2: "net.GND",
+      }}
+    />
+
+    <chip
+      name="usbhost_U2"
+      footprint="sot23_6"
+      pinLabels={{
+        pin1: "DP_A",
+        pin2: "GND",
+        pin3: "DN_A",
+        pin4: "DN_B",
+        pin5: "VBUS",
+        pin6: "DP_B",
+      }}
+      connections={{
+        pin1: "net.USB1_DP",
+        pin2: "net.GND",
+        pin3: "net.USB1_DN",
+        pin4: "net.USB1_DN",
+        pin5: "net.usbhost_usbhost_VBUS",
+        pin6: "net.USB1_DP",
+      }}
+    />
+
+    <chip
+      name="usbhost_J1"
+      footprint="pinrow6"
+      pinLabels={{
+        pin1: "VBUS",
+        pin2: "D-",
+        pin3: "D+",
+        pin4: "GND",
+        pin5: "SHIELD",
+      }}
+      connections={{
+        pin1: "net.usbhost_usbhost_VBUS",
+        pin2: "net.USB1_DN",
+        pin3: "net.USB1_DP",
+        pin4: "net.GND",
+        pin5: "net.GND",
+      }}
+    />
+
+    {/* usdcard */}
+    <chip
+      name="usdcard_J1"
+      footprint="pinrow9"
+      connections={{
+        pin1: "net.SD_DAT2",
+        pin2: "net.SD_DAT3",
+        pin3: "net.SD_CMD",
+        pin4: "net.VDD_3V3",
+        pin5: "net.SD_CLK",
+        pin6: "net.GND",
+        pin7: "net.SD_DAT0",
+        pin8: "net.SD_DAT1",
+        pin9: "net.SD_CD",
+      }}
+    />
+
+    {/* console */}
+    <chip
+      name="console_U1"
+      footprint="soic16"
+      manufacturerPartNumber="CH340C"
+      connections={{
+        pin1: "net.GND",
+        pin2: "net.UART1_RXD",
+        pin3: "net.UART1_TXD",
+        pin4: "net.VDD_3V3",
+        pin5: "net.USB_UART_DP",
+        pin6: "net.USB_UART_DN",
+        pin9: "net.VDD_3V3",
+        pin10: "net.GND",
+        pin11: "net.GND",
+        pin12: "net.GND",
+        pin13: "net.GND",
+        pin16: "net.VDD_3V3",
+      }}
+    />
+
+    {/* jtag */}
+    <chip
+      name="jtag_J1"
+      footprint="pinrow10"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.JTAG_TMS",
+        pin3: "net.GND",
+        pin4: "net.JTAG_TCK",
+        pin5: "net.GND",
+        pin6: "net.JTAG_TDO",
+        pin8: "net.JTAG_TDI",
+        pin9: "net.GND",
+        pin10: "net.SOC_RESET_N",
+      }}
+    />
+
+    {/* bootsel */}
+    <resistor
+      name="bootsel_R1"
+      footprint="0402"
+      resistance="10k"
+      connections={{
+        pin1: "net.BOOT_MODE0",
+        pin2: "net.GND",
+      }}
+    />
+    <resistor
+      name="bootsel_R2"
+      footprint="0402"
+      resistance="10k"
+      connections={{
+        pin1: "net.BOOT_MODE1",
+        pin2: "net.GND",
+      }}
+    />
+    <switch
+      name="bootsel_SW1"
+      footprint="pinrow6"
+      connections={{
+        pin1: "net.GND",
+        pin2: "net.BOOT_MODE0",
+        pin3: "net.VDD_3V3",
+      }}
+    />
+
+    {/* reset */}
+    <chip
+      name="reset_U1"
+      footprint="sot23_5"
+      pinLabels={{
+        pin1: "MR_N",
+        pin2: "GND",
+        pin3: "RESET_N",
+        pin4: "VDD",
+        pin5: "CT",
+      }}
+      connections={{
+        pin1: "net.PWRON",
+        pin2: "net.GND",
+        pin3: "net.SOC_RESET_N",
+        pin4: "net.VDD_3V3",
+        pin5: "net.reset_reset_delay",
+      }}
+    />
+
+    <resistor
+      name="reset_R1"
+      footprint="0402"
+      resistance="10k"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.PWRON",
+      }}
+    />
+
+    <capacitor
+      name="reset_C1"
+      footprint="0402"
+      capacitance="10nF"
+      connections={{
+        pin1: "net.reset_reset_delay",
+        pin2: "net.GND",
+      }}
+    />
+
+    <switch
+      name="reset_SW1"
+      footprint="pinrow2"
+      connections={{
+        pin1: "net.PWRON",
+        pin2: "net.GND",
+      }}
+    />
+
+    {/* eeprom */}
+    <chip
+      name="eeprom_U1"
+      footprint="soic8"
+      manufacturerPartNumber="AT24C256C-SSHL-T"
+      connections={{
+        pin1: "net.GND",
+        pin2: "net.GND",
+        pin3: "net.GND",
+        pin4: "net.GND",
+        pin5: "net.I2C1_SDA",
+        pin6: "net.I2C1_SCL",
+        pin7: "net.GND",
+        pin8: "net.VDD_3V3",
+      }}
+    />
+    <resistor
+      name="eeprom_R1"
+      footprint="0402"
+      resistance="4.7k"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.I2C1_SCL",
+      }}
+    />
+    <resistor
+      name="eeprom_R2"
+      footprint="0402"
+      resistance="4.7k"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.I2C1_SDA",
+      }}
+    />
+
+    {/* i2cpull */}
+    <resistor
+      name="i2cpull_R1"
+      footprint="0402"
+      resistance="4.7k"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.I2C1_SCL",
+      }}
+    />
+    <resistor
+      name="i2cpull_R2"
+      footprint="0402"
+      resistance="4.7k"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.I2C1_SDA",
+      }}
+    />
+
+    {/* leds */}
+    <resistor
+      name="leds_R1"
+      footprint="0805"
+      resistance="1k"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.leds_leds_power_led_anode",
+      }}
+    />
+    <led
+      name="leds_D1"
+      footprint="0805"
+      color="green"
+      connections={{
+        anode: "net.leds_leds_power_led_anode",
+        cathode: "net.LED_PWR",
+      }}
+    />
+    <resistor
+      name="leds_R2"
+      footprint="0805"
+      resistance="1k"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.leds_leds_heartbeat_led_anode",
+      }}
+    />
+    <led
+      name="leds_D2"
+      footprint="0805"
+      color="yellow"
+      connections={{
+        anode: "net.leds_leds_heartbeat_led_anode",
+        cathode: "net.LED_HEARTBEAT",
+      }}
+    />
+
+    {/* expansion */}
+    <chip
+      name="expansion_J1"
+      footprint="pinrow40"
+      connections={{
+        pin1: "net.VDD_3V3",
+        pin2: "net.SYS_5V",
+        pin3: "net.I2C1_SDA",
+        pin4: "net.SYS_5V",
+        pin5: "net.I2C1_SCL",
+        pin6: "net.GND",
+        pin7: "net.expansion_spare_io_1",
+        pin8: "net.UART1_TXD",
+        pin9: "net.GND",
+        pin10: "net.UART1_RXD",
+        pin11: "net.expansion_spare_io_2",
+        pin12: "net.expansion_spare_io_3",
+        pin13: "net.expansion_spare_io_4",
+        pin14: "net.GND",
+        pin15: "net.expansion_spare_io_5",
+        pin16: "net.expansion_spare_io_6",
+        pin17: "net.VDD_3V3",
+        pin18: "net.expansion_spare_io_7",
+        pin19: "net.expansion_spare_io_8",
+        pin20: "net.GND",
+        pin21: "net.expansion_spare_io_9",
+        pin22: "net.expansion_spare_io_10",
+        pin23: "net.expansion_spare_io_11",
+        pin24: "net.expansion_spare_io_12",
+        pin25: "net.GND",
+        pin26: "net.expansion_spare_io_13",
+        pin27: "net.expansion_spare_io_14",
+        pin28: "net.expansion_spare_io_15",
+        pin29: "net.expansion_spare_io_16",
+        pin30: "net.GND",
+        pin31: "net.expansion_spare_io_17",
+        pin32: "net.expansion_spare_io_18",
+        pin33: "net.expansion_spare_io_19",
+        pin34: "net.GND",
+        pin35: "net.SD_DAT0",
+        pin36: "net.SD_DAT1",
+        pin37: "net.expansion_spare_io_20",
+        pin38: "net.expansion_spare_io_21",
+        pin39: "net.GND",
+        pin40: "net.expansion_spare_io_22",
+      }}
+    />
+    <trace from=".codec_U1 > .pin12" to=".audiojack_C1 > .pin1" />
+    <trace from=".codec_U1 > .pin13" to=".audiojack_C2 > .pin1" />
+    <trace from=".audiojack_C1 > .pin2" to=".audiojack_J1 > .pin1" />
+    <trace from=".audiojack_C2 > .pin2" to=".audiojack_J1 > .pin2" />
+    <trace from=".bootsel_R1 > .pin1" to=".bootsel_SW1 > .pin2" />
+    <trace from=".bootsel_SW1 > .pin2" to=".soc_U1 > .pin83" />
+    <trace from=".bootsel_R2 > .pin1" to=".soc_U1 > .pin84" />
+    <trace from=".buck18_U1 > .pin10" to=".buck18_R1 > .pin2" />
+    <trace from=".buck18_R1 > .pin2" to=".buck18_R2 > .pin1" />
+    <trace from=".buck18_U1 > .pin11" to=".buck18_C7 > .pin1" />
+    <trace from=".buck18_U1 > .pin1" to=".buck18_U1 > .pin2" />
+    <trace from=".buck18_U1 > .pin2" to=".buck18_L1 > .pin1" />
+    <trace from=".buck33_U1 > .pin6" to=".buck33_R1 > .pin2" />
+    <trace from=".buck33_R1 > .pin2" to=".buck33_R2 > .pin1" />
+    <trace from=".buck33_R2 > .pin1" to=".buck33_C7 > .pin2" />
+    <trace from=".buck33_U1 > .pin9" to=".buck33_C8 > .pin1" />
+    <trace from=".buck33_U1 > .pin1" to=".buck33_U1 > .pin2" />
+    <trace from=".buck33_U1 > .pin2" to=".buck33_L1 > .pin1" />
+    <trace from=".codec_U1 > .pin22" to=".codec_C6 > .pin2" />
+    <trace from=".codec_U1 > .pin21" to=".codec_C6 > .pin1" />
+    <trace from=".codec_U1 > .pin15" to=".codec_C4 > .pin1" />
+    <trace from=".codec_U1 > .pin14" to=".codec_C5 > .pin1" />
+    <trace from=".codec_U1 > .pin11" to=".codec_R3 > .pin2" />
+    <trace from=".soc_U1 > .pin37" to=".ddr_U1 > .pin17" />
+    <trace from=".soc_U1 > .pin38" to=".ddr_U1 > .pin1" />
+    <trace from=".soc_U1 > .pin39" to=".ddr_U1 > .pin2" />
+    <trace from=".soc_U1 > .pin40" to=".ddr_U1 > .pin3" />
+    <trace from=".soc_U1 > .pin41" to=".ddr_U1 > .pin4" />
+    <trace from=".soc_U1 > .pin42" to=".ddr_U1 > .pin5" />
+    <trace from=".soc_U1 > .pin43" to=".ddr_U1 > .pin6" />
+    <trace from=".soc_U1 > .pin44" to=".ddr_U1 > .pin7" />
+    <trace from=".soc_U1 > .pin45" to=".ddr_U1 > .pin8" />
+    <trace from=".soc_U1 > .pin46" to=".ddr_U1 > .pin9" />
+    <trace from=".soc_U1 > .pin52" to=".ddr_U1 > .pin32" />
+    <trace from=".soc_U1 > .pin48" to=".ddr_U1 > .pin28" />
+    <trace from=".soc_U1 > .pin47" to=".ddr_U1 > .pin27" />
+    <trace from=".soc_U1 > .pin49" to=".ddr_U1 > .pin29" />
+    <trace from=".soc_U1 > .pin50" to=".ddr_U1 > .pin30" />
+    <trace from=".soc_U1 > .pin21" to=".ddr_U1 > .pin1" />
+    <trace from=".soc_U1 > .pin22" to=".ddr_U1 > .pin2" />
+    <trace from=".soc_U1 > .pin31" to=".ddr_U1 > .pin11" />
+    <trace from=".soc_U1 > .pin32" to=".ddr_U1 > .pin12" />
+    <trace from=".soc_U1 > .pin33" to=".ddr_U1 > .pin13" />
+    <trace from=".soc_U1 > .pin34" to=".ddr_U1 > .pin14" />
+    <trace from=".soc_U1 > .pin35" to=".ddr_U1 > .pin15" />
+    <trace from=".soc_U1 > .pin36" to=".ddr_U1 > .pin16" />
+    <trace from=".soc_U1 > .pin23" to=".ddr_U1 > .pin3" />
+    <trace from=".soc_U1 > .pin24" to=".ddr_U1 > .pin4" />
+    <trace from=".soc_U1 > .pin25" to=".ddr_U1 > .pin5" />
+    <trace from=".soc_U1 > .pin26" to=".ddr_U1 > .pin6" />
+    <trace from=".soc_U1 > .pin27" to=".ddr_U1 > .pin7" />
+    <trace from=".soc_U1 > .pin28" to=".ddr_U1 > .pin8" />
+    <trace from=".soc_U1 > .pin29" to=".ddr_U1 > .pin9" />
+    <trace from=".soc_U1 > .pin30" to=".ddr_U1 > .pin10" />
+    <trace from=".soc_U1 > .pin51" to=".ddr_U1 > .pin31" />
+    <trace from=".ddrterm_R1 > .pin2" to=".ddrterm_R2 > .pin1" />
+    <trace from=".soc_U1 > .pin53" to=".ddr_U1 > .pin33" />
+    <trace from=".soc_U1 > .pin54" to=".emmc_U1 > .pin3" />
+    <trace from=".soc_U1 > .pin55" to=".emmc_U1 > .pin4" />
+    <trace from=".soc_U1 > .pin57" to=".emmc_U1 > .pin6" />
+    <trace from=".soc_U1 > .pin58" to=".emmc_U1 > .pin7" />
+    <trace from=".soc_U1 > .pin59" to=".emmc_U1 > .pin8" />
+    <trace from=".soc_U1 > .pin60" to=".emmc_U1 > .pin9" />
+    <trace from=".soc_U1 > .pin61" to=".emmc_U1 > .pin10" />
+    <trace from=".soc_U1 > .pin62" to=".emmc_U1 > .pin11" />
+    <trace from=".soc_U1 > .pin63" to=".emmc_U1 > .pin12" />
+    <trace from=".soc_U1 > .pin64" to=".emmc_U1 > .pin13" />
+    <trace from=".soc_U1 > .pin56" to=".emmc_U1 > .pin5" />
+    <trace from=".phy_U1 > .pin18" to=".phy_R1 > .pin1" />
+    <trace from=".phy_U1 > .pin19" to=".phy_R2 > .pin1" />
+    <trace from=".phy_U1 > .pin23" to=".magjack_J1 > .pin4" />
+    <trace from=".phy_U1 > .pin22" to=".magjack_J1 > .pin3" />
+    <trace from=".phy_U1 > .pin21" to=".magjack_J1 > .pin2" />
+    <trace from=".phy_U1 > .pin20" to=".magjack_J1 > .pin1" />
+    <trace from=".phy_U1 > .pin24" to=".ethxtal_Y1 > .pin1" />
+    <trace from=".ethxtal_Y1 > .pin1" to=".ethxtal_C1 > .pin1" />
+    <trace from=".phy_U1 > .pin25" to=".ethxtal_Y1 > .pin2" />
+    <trace from=".ethxtal_Y1 > .pin2" to=".ethxtal_C2 > .pin1" />
+    <trace from=".pmic_U1 > .pin22" to=".pmic_U1 > .pin23" />
+    <trace from=".pmic_U1 > .pin23" to=".pmic_U1 > .pin24" />
+    <trace from=".pmic_U1 > .pin24" to=".pmic_U1 > .pin25" />
+    <trace from=".pmic_U1 > .pin25" to=".pmic_U1 > .pin26" />
+    <trace from=".pmic_U1 > .pin26" to=".pmic_U1 > .pin27" />
+    <trace from=".pmic_U1 > .pin27" to=".pmic_U1 > .pin28" />
+    <trace from=".pmic_U1 > .pin28" to=".pmic_U1 > .pin29" />
+    <trace from=".pmic_U1 > .pin29" to=".pmic_U1 > .pin30" />
+    <trace from=".pmic_U1 > .pin30" to=".pmic_U1 > .pin31" />
+    <trace from=".pmic_U1 > .pin31" to=".pmic_U1 > .pin32" />
+    <trace from=".pmic_U1 > .pin32" to=".pmic_U1 > .pin33" />
+    <trace from=".pmic_U1 > .pin33" to=".pmic_U1 > .pin34" />
+    <trace from=".pmic_U1 > .pin34" to=".pmic_U1 > .pin42" />
+    <trace from=".pmic_U1 > .pin42" to=".pmic_U1 > .pin43" />
+    <trace from=".pmic_U1 > .pin43" to=".pmic_U1 > .pin44" />
+    <trace from=".pmic_U1 > .pin44" to=".pmic_U1 > .pin45" />
+    <trace from=".pmic_U1 > .pin45" to=".pmic_U1 > .pin46" />
+    <trace from=".pmic_U1 > .pin46" to=".pmic_U1 > .pin47" />
+    <trace from=".pmic_U1 > .pin47" to=".pmic_U1 > .pin48" />
+    <trace from=".pmic_U1 > .pin48" to=".pmic_U1 > .pin49" />
+    <trace from=".pmic_U1 > .pin49" to=".pmic_U1 > .pin50" />
+    <trace from=".pmic_U1 > .pin50" to=".pmic_U1 > .pin51" />
+    <trace from=".pmic_U1 > .pin51" to=".pmic_U1 > .pin52" />
+    <trace from=".pmic_U1 > .pin52" to=".pmic_U1 > .pin53" />
+    <trace from=".pmic_U1 > .pin53" to=".pmic_U1 > .pin54" />
+    <trace from=".pmic_U1 > .pin54" to=".pmic_U1 > .pin55" />
+    <trace from=".pmic_U1 > .pin55" to=".pmic_U1 > .pin56" />
+    <trace from=".pmic_U1 > .pin56" to=".pmic_U1 > .pin57" />
+    <trace from=".pmic_U1 > .pin57" to=".pmic_U1 > .pin58" />
+    <trace from=".pmic_U1 > .pin58" to=".pmic_U1 > .pin59" />
+    <trace from=".pmic_U1 > .pin59" to=".pmic_U1 > .pin60" />
+    <trace from=".pmic_U1 > .pin60" to=".pmic_U1 > .pin61" />
+    <trace from=".pmic_U1 > .pin61" to=".pmic_U1 > .pin62" />
+    <trace from=".pmic_U1 > .pin62" to=".pmic_U1 > .pin63" />
+    <trace from=".pmic_U1 > .pin63" to=".pmic_U1 > .pin64" />
+    <trace from=".pmic_U1 > .pin64" to=".pmic_U1 > .pin65" />
+    <trace from=".pmic_U1 > .pin65" to=".pmic_U1 > .pin66" />
+    <trace from=".pmic_U1 > .pin66" to=".pmic_U1 > .pin67" />
+    <trace from=".pmic_U1 > .pin67" to=".pmic_U1 > .pin68" />
+    <trace from=".pmic_U1 > .pin68" to=".pmic_C1 > .pin2" />
+    <trace from=".pmic_C1 > .pin2" to=".pmic_C2 > .pin2" />
+    <trace from=".pmic_C2 > .pin2" to=".pmic_C3 > .pin2" />
+    <trace from=".pmic_C3 > .pin2" to=".pmic_C4 > .pin2" />
+    <trace from=".pmic_C4 > .pin2" to=".pmic_C5 > .pin2" />
+    <trace from=".pmic_C5 > .pin2" to=".pmic_C6 > .pin2" />
+    <trace from=".pmic_C6 > .pin2" to=".pmic_C7 > .pin2" />
+    <trace from=".pmic_C7 > .pin2" to=".pmic_C8 > .pin2" />
+    <trace from=".pmic_C8 > .pin2" to=".pmic_C9 > .pin2" />
+    <trace from=".pmic_C9 > .pin2" to=".pmic_C10 > .pin2" />
+    <trace from=".pmic_C10 > .pin2" to=".pmic_C11 > .pin2" />
+    <trace from=".pmic_C11 > .pin2" to=".pmic_C12 > .pin2" />
+    <trace from=".pmic_C12 > .pin2" to=".pmic_R5 > .pin2" />
+    <trace from=".pmic_R5 > .pin2" to=".usbcpd_J1 > .pin1" />
+    <trace from=".usbcpd_J1 > .pin1" to=".usbcpd_J1 > .pin8" />
+    <trace from=".usbcpd_J1 > .pin8" to=".usbcpd_J1 > .pin9" />
+    <trace from=".usbcpd_J1 > .pin9" to=".usbcpd_J1 > .pin16" />
+    <trace from=".usbcpd_J1 > .pin16" to=".usbcpd_J1 > .pin17" />
+    <trace from=".usbcpd_J1 > .pin17" to=".usbcpd_R1 > .pin2" />
+    <trace from=".usbcpd_R1 > .pin2" to=".usbcpd_R2 > .pin2" />
+    <trace from=".usbcpd_R2 > .pin2" to=".usbcpd_U1 > .pin4" />
+    <trace from=".usbcpd_U1 > .pin4" to=".usbcpd_U2 > .pin5" />
+    <trace from=".usbcpd_U2 > .pin5" to=".usbcpd_D1 > .pin1" />
+    <trace from=".usbcpd_D1 > .pin1" to=".inprot_R1 > .pin2" />
+    <trace from=".inprot_R1 > .pin2" to=".buck33_U1 > .pin3" />
+    <trace from=".buck33_U1 > .pin3" to=".buck33_U1 > .pin4" />
+    <trace from=".buck33_U1 > .pin4" to=".buck33_U1 > .pin5" />
+    <trace from=".buck33_U1 > .pin5" to=".buck33_C1 > .pin2" />
+    <trace from=".buck33_C1 > .pin2" to=".buck33_C2 > .pin2" />
+    <trace from=".buck33_C2 > .pin2" to=".buck33_C3 > .pin2" />
+    <trace from=".buck33_C3 > .pin2" to=".buck33_C4 > .pin2" />
+    <trace from=".buck33_C4 > .pin2" to=".buck33_C5 > .pin2" />
+    <trace from=".buck33_C5 > .pin2" to=".buck33_C6 > .pin2" />
+    <trace from=".buck33_C6 > .pin2" to=".buck33_R2 > .pin2" />
+    <trace from=".buck33_R2 > .pin2" to=".buck33_C8 > .pin2" />
+    <trace from=".buck33_C8 > .pin2" to=".buck18_U1 > .pin3" />
+    <trace from=".buck18_U1 > .pin3" to=".buck18_U1 > .pin4" />
+    <trace from=".buck18_U1 > .pin4" to=".buck18_U1 > .pin9" />
+    <trace from=".buck18_U1 > .pin9" to=".buck18_U1 > .pin12" />
+    <trace from=".buck18_U1 > .pin12" to=".buck18_C1 > .pin2" />
+    <trace from=".buck18_C1 > .pin2" to=".buck18_C2 > .pin2" />
+    <trace from=".buck18_C2 > .pin2" to=".buck18_C3 > .pin2" />
+    <trace from=".buck18_C3 > .pin2" to=".buck18_C4 > .pin2" />
+    <trace from=".buck18_C4 > .pin2" to=".buck18_C5 > .pin2" />
+    <trace from=".buck18_C5 > .pin2" to=".buck18_C6 > .pin2" />
+    <trace from=".buck18_C6 > .pin2" to=".buck18_R2 > .pin2" />
+    <trace from=".buck18_R2 > .pin2" to=".buck18_C7 > .pin2" />
+    <trace from=".buck18_C7 > .pin2" to=".ldo06_U1 > .pin2" />
+    <trace from=".ldo06_U1 > .pin2" to=".ldo06_C1 > .pin2" />
+    <trace from=".ldo06_C1 > .pin2" to=".ldo06_C2 > .pin2" />
+    <trace from=".ldo06_C2 > .pin2" to=".ldortc_U1 > .pin2" />
+    <trace from=".ldortc_U1 > .pin2" to=".ldortc_C1 > .pin2" />
+    <trace from=".ldortc_C1 > .pin2" to=".ldortc_C2 > .pin2" />
+    <trace from=".ldortc_C2 > .pin2" to=".ldoaudio_U1 > .pin1" />
+    <trace from=".ldoaudio_U1 > .pin1" to=".ldoaudio_C1 > .pin2" />
+    <trace from=".ldoaudio_C1 > .pin2" to=".ldoaudio_C2 > .pin2" />
+    <trace from=".ldoaudio_C2 > .pin2" to=".ldohdmi_U1 > .pin2" />
+    <trace from=".ldohdmi_U1 > .pin2" to=".ldohdmi_C1 > .pin2" />
+    <trace from=".ldohdmi_C1 > .pin2" to=".ldohdmi_C2 > .pin2" />
+    <trace from=".ldohdmi_C2 > .pin2" to=".bulk_C1 > .pin2" />
+    <trace from=".bulk_C1 > .pin2" to=".bulk_C2 > .pin2" />
+    <trace from=".bulk_C2 > .pin2" to=".railcaps_C1 > .pin2" />
+    <trace from=".railcaps_C1 > .pin2" to=".railcaps_C2 > .pin2" />
+    <trace from=".railcaps_C2 > .pin2" to=".railcaps_C3 > .pin2" />
+    <trace from=".railcaps_C3 > .pin2" to=".railcaps_C4 > .pin2" />
+    <trace from=".railcaps_C4 > .pin2" to=".railcaps_C5 > .pin2" />
+    <trace from=".railcaps_C5 > .pin2" to=".railcaps_C6 > .pin2" />
+    <trace from=".railcaps_C6 > .pin2" to=".railcaps_C7 > .pin2" />
+    <trace from=".railcaps_C7 > .pin2" to=".railcaps_C8 > .pin2" />
+    <trace from=".railcaps_C8 > .pin2" to=".railcaps_C9 > .pin2" />
+    <trace from=".railcaps_C9 > .pin2" to=".railcaps_C10 > .pin2" />
+    <trace from=".railcaps_C10 > .pin2" to=".phy_U1 > .pin4" />
+    <trace from=".phy_U1 > .pin4" to=".phy_R4 > .pin2" />
+    <trace from=".phy_R4 > .pin2" to=".phy_R5 > .pin2" />
+    <trace from=".phy_R5 > .pin2" to=".ethxtal_C1 > .pin2" />
+    <trace from=".ethxtal_C1 > .pin2" to=".ethxtal_C2 > .pin2" />
+    <trace from=".ethxtal_C2 > .pin2" to=".magjack_J1 > .pin15" />
+    <trace from=".magjack_J1 > .pin15" to=".magjack_C1 > .pin2" />
+    <trace from=".magjack_C1 > .pin2" to=".hdmitx_D1 > .pin2" />
+    <trace from=".hdmitx_D1 > .pin2" to=".hdmitx_D2 > .pin2" />
+    <trace from=".hdmitx_D2 > .pin2" to=".hdmitx_D3 > .pin2" />
+    <trace from=".hdmitx_D3 > .pin2" to=".hdmitx_D4 > .pin2" />
+    <trace from=".hdmitx_D4 > .pin2" to=".hdmitx_D5 > .pin2" />
+    <trace from=".hdmitx_D5 > .pin2" to=".hdmitx_D6 > .pin2" />
+    <trace from=".hdmitx_D6 > .pin2" to=".hdmitx_D7 > .pin2" />
+    <trace from=".hdmitx_D7 > .pin2" to=".hdmitx_D8 > .pin2" />
+    <trace from=".hdmitx_D8 > .pin2" to=".hdmitx_D9 > .pin2" />
+    <trace from=".hdmitx_D9 > .pin2" to=".hdmitx_D10 > .pin2" />
+    <trace from=".hdmitx_D10 > .pin2" to=".hdmitx_J1 > .pin2" />
+    <trace from=".hdmitx_J1 > .pin2" to=".hdmitx_J1 > .pin5" />
+    <trace from=".hdmitx_J1 > .pin5" to=".hdmitx_J1 > .pin8" />
+    <trace from=".hdmitx_J1 > .pin8" to=".hdmitx_J1 > .pin11" />
+    <trace from=".hdmitx_J1 > .pin11" to=".hdmitx_J1 > .pin17" />
+    <trace from=".hdmitx_J1 > .pin17" to=".hdmiconn_J1 > .pin2" />
+    <trace from=".hdmiconn_J1 > .pin2" to=".hdmiconn_J1 > .pin5" />
+    <trace from=".hdmiconn_J1 > .pin5" to=".hdmiconn_J1 > .pin8" />
+    <trace from=".hdmiconn_J1 > .pin8" to=".hdmiconn_J1 > .pin11" />
+    <trace from=".hdmiconn_J1 > .pin11" to=".hdmiconn_J1 > .pin17" />
+    <trace from=".hdmiconn_J1 > .pin17" to=".hdmiconn_D1 > .pin2" />
+    <trace from=".hdmiconn_D1 > .pin2" to=".hdmiconn_D2 > .pin2" />
+    <trace from=".hdmiconn_D2 > .pin2" to=".hdmiconn_D3 > .pin2" />
+    <trace from=".hdmiconn_D3 > .pin2" to=".hdmiconn_D4 > .pin2" />
+    <trace from=".hdmiconn_D4 > .pin2" to=".soc_U1 > .pin16" />
+    <trace from=".soc_U1 > .pin16" to=".hdmiconn_D5 > .pin2" />
+    <trace from=".hdmiconn_D5 > .pin2" to=".hdmiconn_D6 > .pin2" />
+    <trace from=".hdmiconn_D6 > .pin2" to=".hdmiconn_D7 > .pin2" />
+    <trace from=".hdmiconn_D7 > .pin2" to=".hdmiconn_D8 > .pin2" />
+    <trace from=".hdmiconn_D8 > .pin2" to=".codec_U1 > .pin3" />
+    <trace from=".codec_U1 > .pin3" to=".codec_U1 > .pin16" />
+    <trace from=".codec_U1 > .pin16" to=".codec_U1 > .pin17" />
+    <trace from=".codec_U1 > .pin17" to=".codec_U1 > .pin18" />
+    <trace from=".codec_U1 > .pin18" to=".codec_U1 > .pin19" />
+    <trace from=".codec_U1 > .pin19" to=".codec_U1 > .pin20" />
+    <trace from=".codec_U1 > .pin20" to=".codec_U1 > .pin24" />
+    <trace from=".codec_U1 > .pin24" to=".codec_U1 > .pin25" />
+    <trace from=".codec_U1 > .pin25" to=".codec_U1 > .pin26" />
+    <trace from=".codec_U1 > .pin26" to=".codec_U1 > .pin27" />
+    <trace from=".codec_U1 > .pin27" to=".codec_U1 > .pin28" />
+    <trace from=".codec_U1 > .pin28" to=".codec_U1 > .pin29" />
+    <trace from=".codec_U1 > .pin29" to=".codec_U1 > .pin30" />
+    <trace from=".codec_U1 > .pin30" to=".codec_U1 > .pin31" />
+    <trace from=".codec_U1 > .pin31" to=".codec_U1 > .pin32" />
+    <trace from=".codec_U1 > .pin32" to=".codec_C1 > .pin2" />
+    <trace from=".codec_C1 > .pin2" to=".codec_C2 > .pin2" />
+    <trace from=".codec_C2 > .pin2" to=".codec_C3 > .pin2" />
+    <trace from=".codec_C3 > .pin2" to=".codec_C4 > .pin2" />
+    <trace from=".codec_C4 > .pin2" to=".codec_C5 > .pin2" />
+    <trace from=".codec_C5 > .pin2" to=".audiojack_J1 > .pin3" />
+    <trace from=".audiojack_J1 > .pin3" to=".usbhost_U1 > .pin2" />
+    <trace from=".usbhost_U1 > .pin2" to=".usbhost_R1 > .pin2" />
+    <trace from=".usbhost_R1 > .pin2" to=".usbhost_U2 > .pin2" />
+    <trace from=".usbhost_U2 > .pin2" to=".usbhost_J1 > .pin4" />
+    <trace from=".usbhost_J1 > .pin4" to=".usbhost_J1 > .pin5" />
+    <trace from=".usbhost_J1 > .pin5" to=".usdcard_J1 > .pin6" />
+    <trace from=".usdcard_J1 > .pin6" to=".console_U1 > .pin1" />
+    <trace from=".console_U1 > .pin1" to=".soc_U1 > .pin17" />
+    <trace from=".soc_U1 > .pin17" to=".console_U1 > .pin10" />
+    <trace from=".console_U1 > .pin10" to=".console_U1 > .pin11" />
+    <trace from=".console_U1 > .pin11" to=".console_U1 > .pin12" />
+    <trace from=".console_U1 > .pin12" to=".console_U1 > .pin13" />
+    <trace from=".console_U1 > .pin13" to=".jtag_J1 > .pin3" />
+    <trace from=".jtag_J1 > .pin3" to=".jtag_J1 > .pin5" />
+    <trace from=".jtag_J1 > .pin5" to=".jtag_J1 > .pin9" />
+    <trace from=".jtag_J1 > .pin9" to=".bootsel_R1 > .pin2" />
+    <trace from=".bootsel_R1 > .pin2" to=".bootsel_R2 > .pin2" />
+    <trace from=".bootsel_R2 > .pin2" to=".bootsel_SW1 > .pin1" />
+    <trace from=".bootsel_SW1 > .pin1" to=".reset_U1 > .pin2" />
+    <trace from=".reset_U1 > .pin2" to=".reset_C1 > .pin2" />
+    <trace from=".reset_C1 > .pin2" to=".reset_SW1 > .pin2" />
+    <trace from=".reset_SW1 > .pin2" to=".eeprom_U1 > .pin1" />
+    <trace from=".eeprom_U1 > .pin1" to=".eeprom_U1 > .pin2" />
+    <trace from=".eeprom_U1 > .pin2" to=".eeprom_U1 > .pin3" />
+    <trace from=".eeprom_U1 > .pin3" to=".eeprom_U1 > .pin4" />
+    <trace from=".eeprom_U1 > .pin4" to=".eeprom_U1 > .pin7" />
+    <trace from=".eeprom_U1 > .pin7" to=".expansion_J1 > .pin6" />
+    <trace from=".expansion_J1 > .pin6" to=".expansion_J1 > .pin9" />
+    <trace from=".expansion_J1 > .pin9" to=".expansion_J1 > .pin14" />
+    <trace from=".expansion_J1 > .pin14" to=".expansion_J1 > .pin20" />
+    <trace from=".expansion_J1 > .pin20" to=".expansion_J1 > .pin25" />
+    <trace from=".expansion_J1 > .pin25" to=".expansion_J1 > .pin30" />
+    <trace from=".expansion_J1 > .pin30" to=".expansion_J1 > .pin34" />
+    <trace from=".expansion_J1 > .pin34" to=".soc_U1 > .pin18" />
+    <trace from=".soc_U1 > .pin18" to=".expansion_J1 > .pin39" />
+    <trace from=".expansion_J1 > .pin39" to=".soc_U1 > .pin19" />
+    <trace from=".soc_U1 > .pin19" to=".soc_U1 > .pin20" />
+    <trace from=".soc_U1 > .pin20" to=".socdecoup_C1 > .pin2" />
+    <trace from=".socdecoup_C1 > .pin2" to=".socdecoup_C2 > .pin2" />
+    <trace from=".socdecoup_C2 > .pin2" to=".socdecoup_C3 > .pin2" />
+    <trace from=".socdecoup_C3 > .pin2" to=".socdecoup_C4 > .pin2" />
+    <trace from=".socdecoup_C4 > .pin2" to=".socdecoup_C5 > .pin2" />
+    <trace from=".socdecoup_C5 > .pin2" to=".socdecoup_C6 > .pin2" />
+    <trace from=".socdecoup_C6 > .pin2" to=".socdecoup_C7 > .pin2" />
+    <trace from=".socdecoup_C7 > .pin2" to=".socdecoup_C8 > .pin2" />
+    <trace from=".socdecoup_C8 > .pin2" to=".socdecoup_C9 > .pin2" />
+    <trace from=".socdecoup_C9 > .pin2" to=".socdecoup_C10 > .pin2" />
+    <trace from=".socdecoup_C10 > .pin2" to=".socdecoup_C11 > .pin2" />
+    <trace from=".socdecoup_C11 > .pin2" to=".socdecoup_C12 > .pin2" />
+    <trace from=".socdecoup_C12 > .pin2" to=".socdecoup_C13 > .pin2" />
+    <trace from=".socdecoup_C13 > .pin2" to=".socdecoup_C14 > .pin2" />
+    <trace from=".socdecoup_C14 > .pin2" to=".socdecoup_C15 > .pin2" />
+    <trace from=".socdecoup_C15 > .pin2" to=".socdecoup_C16 > .pin2" />
+    <trace from=".socdecoup_C16 > .pin2" to=".socdecoup_C17 > .pin2" />
+    <trace from=".socdecoup_C17 > .pin2" to=".socdecoup_C18 > .pin2" />
+    <trace from=".socdecoup_C18 > .pin2" to=".socdecoup_C19 > .pin2" />
+    <trace from=".socdecoup_C19 > .pin2" to=".socdecoup_C20 > .pin2" />
+    <trace from=".socdecoup_C20 > .pin2" to=".socdecoup_C21 > .pin2" />
+    <trace from=".socdecoup_C21 > .pin2" to=".socdecoup_C22 > .pin2" />
+    <trace from=".socdecoup_C22 > .pin2" to=".socdecoup_C23 > .pin2" />
+    <trace from=".socdecoup_C23 > .pin2" to=".socdecoup_C24 > .pin2" />
+    <trace from=".socdecoup_C24 > .pin2" to=".socdecoup_C25 > .pin2" />
+    <trace from=".socdecoup_C25 > .pin2" to=".socdecoup_C26 > .pin2" />
+    <trace from=".socdecoup_C26 > .pin2" to=".socdecoup_C27 > .pin2" />
+    <trace from=".socdecoup_C27 > .pin2" to=".socdecoup_C28 > .pin2" />
+    <trace from=".socdecoup_C28 > .pin2" to=".socdecoup_C29 > .pin2" />
+    <trace from=".socdecoup_C29 > .pin2" to=".socdecoup_C30 > .pin2" />
+    <trace from=".socdecoup_C30 > .pin2" to=".socdecoup_C31 > .pin2" />
+    <trace from=".socdecoup_C31 > .pin2" to=".socdecoup_C32 > .pin2" />
+    <trace from=".socdecoup_C32 > .pin2" to=".socdecoup_C33 > .pin2" />
+    <trace from=".socdecoup_C33 > .pin2" to=".socdecoup_C34 > .pin2" />
+    <trace from=".socdecoup_C34 > .pin2" to=".socdecoup_C35 > .pin2" />
+    <trace from=".socdecoup_C35 > .pin2" to=".socdecoup_C36 > .pin2" />
+    <trace from=".socdecoup_C36 > .pin2" to=".socdecoup_C37 > .pin2" />
+    <trace from=".socdecoup_C37 > .pin2" to=".socdecoup_C38 > .pin2" />
+    <trace from=".socdecoup_C38 > .pin2" to=".socdecoup_C39 > .pin2" />
+    <trace from=".socdecoup_C39 > .pin2" to=".socdecoup_C40 > .pin2" />
+    <trace from=".socdecoup_C40 > .pin2" to=".xtal24_C1 > .pin2" />
+    <trace from=".xtal24_C1 > .pin2" to=".xtal24_C2 > .pin2" />
+    <trace from=".xtal24_C2 > .pin2" to=".rtcxtal_C1 > .pin2" />
+    <trace from=".rtcxtal_C1 > .pin2" to=".rtcxtal_C2 > .pin2" />
+    <trace from=".rtcxtal_C2 > .pin2" to=".ddr_U1 > .pin40" />
+    <trace from=".ddr_U1 > .pin40" to=".ddr_U1 > .pin41" />
+    <trace from=".ddr_U1 > .pin41" to=".ddr_U1 > .pin42" />
+    <trace from=".ddr_U1 > .pin42" to=".ddr_U1 > .pin43" />
+    <trace from=".ddr_U1 > .pin43" to=".ddr_U1 > .pin44" />
+    <trace from=".ddr_U1 > .pin44" to=".ddrterm_R2 > .pin2" />
+    <trace from=".ddrterm_R2 > .pin2" to=".ddrterm_R3 > .pin2" />
+    <trace from=".ddrterm_R3 > .pin2" to=".ddrdecoup_C1 > .pin2" />
+    <trace from=".ddrdecoup_C1 > .pin2" to=".ddrdecoup_C2 > .pin2" />
+    <trace from=".ddrdecoup_C2 > .pin2" to=".ddrdecoup_C3 > .pin2" />
+    <trace from=".ddrdecoup_C3 > .pin2" to=".ddrdecoup_C4 > .pin2" />
+    <trace from=".ddrdecoup_C4 > .pin2" to=".ddrdecoup_C5 > .pin2" />
+    <trace from=".ddrdecoup_C5 > .pin2" to=".ddrdecoup_C6 > .pin2" />
+    <trace from=".ddrdecoup_C6 > .pin2" to=".emmc_U1 > .pin14" />
+    <trace from=".emmc_U1 > .pin14" to=".emmc_U1 > .pin15" />
+    <trace from=".emmc_U1 > .pin15" to=".emmc_U1 > .pin16" />
+    <trace from=".emmc_U1 > .pin16" to=".emmc_U1 > .pin17" />
+    <trace from=".emmc_U1 > .pin17" to=".emmc_U1 > .pin18" />
+    <trace from=".emmc_U1 > .pin18" to=".emmc_U1 > .pin19" />
+    <trace from=".emmc_U1 > .pin19" to=".emmc_U1 > .pin20" />
+    <trace from=".emmc_U1 > .pin20" to=".emmc_U1 > .pin21" />
+    <trace from=".emmc_U1 > .pin21" to=".emmc_U1 > .pin22" />
+    <trace from=".emmc_U1 > .pin22" to=".emmc_U1 > .pin23" />
+    <trace from=".emmc_U1 > .pin23" to=".emmc_U1 > .pin24" />
+    <trace from=".emmc_U1 > .pin24" to=".emmc_U1 > .pin25" />
+    <trace from=".emmc_U1 > .pin25" to=".emmc_U1 > .pin26" />
+    <trace from=".emmc_U1 > .pin26" to=".emmc_U1 > .pin27" />
+    <trace from=".emmc_U1 > .pin27" to=".emmc_U1 > .pin28" />
+    <trace from=".emmc_U1 > .pin28" to=".emmc_U1 > .pin29" />
+    <trace from=".emmc_U1 > .pin29" to=".emmc_U1 > .pin30" />
+    <trace from=".emmc_U1 > .pin30" to=".emmc_U1 > .pin31" />
+    <trace from=".emmc_U1 > .pin31" to=".emmc_U1 > .pin32" />
+    <trace from=".emmc_U1 > .pin32" to=".emmc_U1 > .pin33" />
+    <trace from=".emmc_U1 > .pin33" to=".emmc_U1 > .pin34" />
+    <trace from=".emmc_U1 > .pin34" to=".emmc_U1 > .pin35" />
+    <trace from=".emmc_U1 > .pin35" to=".emmc_U1 > .pin36" />
+    <trace from=".emmc_U1 > .pin36" to=".emmc_U1 > .pin37" />
+    <trace from=".emmc_U1 > .pin37" to=".emmc_U1 > .pin38" />
+    <trace from=".emmc_U1 > .pin38" to=".emmc_U1 > .pin39" />
+    <trace from=".emmc_U1 > .pin39" to=".emmc_U1 > .pin40" />
+    <trace from=".emmc_U1 > .pin40" to=".emmc_U1 > .pin41" />
+    <trace from=".emmc_U1 > .pin41" to=".emmc_U1 > .pin42" />
+    <trace from=".emmc_U1 > .pin42" to=".emmc_U1 > .pin43" />
+    <trace from=".emmc_U1 > .pin43" to=".emmc_U1 > .pin44" />
+    <trace from=".emmc_U1 > .pin44" to=".emmc_U1 > .pin45" />
+    <trace from=".emmc_U1 > .pin45" to=".emmc_U1 > .pin46" />
+    <trace from=".emmc_U1 > .pin46" to=".emmc_U1 > .pin47" />
+    <trace from=".emmc_U1 > .pin47" to=".emmc_U1 > .pin48" />
+    <trace from=".emmc_U1 > .pin48" to=".emmc_U1 > .pin49" />
+    <trace from=".emmc_U1 > .pin49" to=".emmc_U1 > .pin50" />
+    <trace from=".emmc_U1 > .pin50" to=".emmc_U1 > .pin51" />
+    <trace from=".emmc_U1 > .pin51" to=".emmc_U1 > .pin52" />
+    <trace from=".emmc_U1 > .pin52" to=".emmc_U1 > .pin53" />
+    <trace from=".emmc_U1 > .pin53" to=".emmc_U1 > .pin54" />
+    <trace from=".emmc_U1 > .pin54" to=".emmc_U1 > .pin55" />
+    <trace from=".emmc_U1 > .pin55" to=".emmc_U1 > .pin56" />
+    <trace from=".emmc_U1 > .pin56" to=".emmc_U1 > .pin57" />
+    <trace from=".emmc_U1 > .pin57" to=".emmc_U1 > .pin58" />
+    <trace from=".emmc_U1 > .pin58" to=".emmc_U1 > .pin59" />
+    <trace from=".emmc_U1 > .pin59" to=".emmc_U1 > .pin60" />
+    <trace from=".emmc_U1 > .pin60" to=".emmc_U1 > .pin61" />
+    <trace from=".emmc_U1 > .pin61" to=".emmc_U1 > .pin62" />
+    <trace from=".emmc_U1 > .pin62" to=".emmc_U1 > .pin63" />
+    <trace from=".emmc_U1 > .pin63" to=".emmc_U1 > .pin64" />
+    <trace from=".emmc_U1 > .pin64" to=".emmc_U1 > .pin65" />
+    <trace from=".emmc_U1 > .pin65" to=".emmc_U1 > .pin66" />
+    <trace from=".emmc_U1 > .pin66" to=".emmc_U1 > .pin67" />
+    <trace from=".emmc_U1 > .pin67" to=".emmc_U1 > .pin68" />
+    <trace from=".emmc_U1 > .pin68" to=".emmc_U1 > .pin69" />
+    <trace from=".emmc_U1 > .pin69" to=".emmc_U1 > .pin70" />
+    <trace from=".emmc_U1 > .pin70" to=".emmc_U1 > .pin71" />
+    <trace from=".emmc_U1 > .pin71" to=".emmc_U1 > .pin72" />
+    <trace from=".emmc_U1 > .pin72" to=".emmc_U1 > .pin73" />
+    <trace from=".emmc_U1 > .pin73" to=".emmc_U1 > .pin74" />
+    <trace from=".emmc_U1 > .pin74" to=".emmc_U1 > .pin75" />
+    <trace from=".emmc_U1 > .pin75" to=".emmc_U1 > .pin76" />
+    <trace from=".emmc_U1 > .pin76" to=".emmc_U1 > .pin77" />
+    <trace from=".emmc_U1 > .pin77" to=".emmc_U1 > .pin78" />
+    <trace from=".emmc_U1 > .pin78" to=".emmc_U1 > .pin79" />
+    <trace from=".emmc_U1 > .pin79" to=".emmc_U1 > .pin80" />
+    <trace from=".emmc_U1 > .pin80" to=".emmc_U1 > .pin81" />
+    <trace from=".emmc_U1 > .pin81" to=".emmc_U1 > .pin82" />
+    <trace from=".emmc_U1 > .pin82" to=".emmc_U1 > .pin83" />
+    <trace from=".emmc_U1 > .pin83" to=".emmc_U1 > .pin84" />
+    <trace from=".emmc_U1 > .pin84" to=".emmc_U1 > .pin85" />
+    <trace from=".emmc_U1 > .pin85" to=".emmc_U1 > .pin86" />
+    <trace from=".emmc_U1 > .pin86" to=".emmc_U1 > .pin87" />
+    <trace from=".emmc_U1 > .pin87" to=".emmc_U1 > .pin88" />
+    <trace from=".emmc_U1 > .pin88" to=".emmc_U1 > .pin89" />
+    <trace from=".emmc_U1 > .pin89" to=".emmc_U1 > .pin90" />
+    <trace from=".emmc_U1 > .pin90" to=".emmc_U1 > .pin91" />
+    <trace from=".emmc_U1 > .pin91" to=".emmc_U1 > .pin92" />
+    <trace from=".emmc_U1 > .pin92" to=".emmc_U1 > .pin93" />
+    <trace from=".emmc_U1 > .pin93" to=".emmc_U1 > .pin94" />
+    <trace from=".emmc_U1 > .pin94" to=".emmc_U1 > .pin95" />
+    <trace from=".emmc_U1 > .pin95" to=".emmc_U1 > .pin96" />
+    <trace from=".emmc_U1 > .pin96" to=".emmc_U1 > .pin97" />
+    <trace from=".emmc_U1 > .pin97" to=".emmc_U1 > .pin98" />
+    <trace from=".emmc_U1 > .pin98" to=".emmc_U1 > .pin99" />
+    <trace from=".emmc_U1 > .pin99" to=".emmc_U1 > .pin100" />
+    <trace from=".emmc_U1 > .pin100" to=".emmc_U1 > .pin101" />
+    <trace from=".emmc_U1 > .pin101" to=".emmc_U1 > .pin102" />
+    <trace from=".emmc_U1 > .pin102" to=".emmc_U1 > .pin103" />
+    <trace from=".emmc_U1 > .pin103" to=".emmc_U1 > .pin104" />
+    <trace from=".emmc_U1 > .pin104" to=".emmc_U1 > .pin105" />
+    <trace from=".emmc_U1 > .pin105" to=".emmc_U1 > .pin106" />
+    <trace from=".emmc_U1 > .pin106" to=".emmc_U1 > .pin107" />
+    <trace from=".emmc_U1 > .pin107" to=".emmc_U1 > .pin108" />
+    <trace from=".emmc_U1 > .pin108" to=".emmc_U1 > .pin109" />
+    <trace from=".emmc_U1 > .pin109" to=".emmc_U1 > .pin110" />
+    <trace from=".emmc_U1 > .pin110" to=".emmc_U1 > .pin111" />
+    <trace from=".emmc_U1 > .pin111" to=".emmc_U1 > .pin112" />
+    <trace from=".emmc_U1 > .pin112" to=".emmc_U1 > .pin113" />
+    <trace from=".emmc_U1 > .pin113" to=".emmc_U1 > .pin114" />
+    <trace from=".emmc_U1 > .pin114" to=".emmc_U1 > .pin115" />
+    <trace from=".emmc_U1 > .pin115" to=".emmc_U1 > .pin116" />
+    <trace from=".emmc_U1 > .pin116" to=".emmc_U1 > .pin117" />
+    <trace from=".emmc_U1 > .pin117" to=".emmc_U1 > .pin118" />
+    <trace from=".emmc_U1 > .pin118" to=".emmc_U1 > .pin119" />
+    <trace from=".emmc_U1 > .pin119" to=".emmc_U1 > .pin120" />
+    <trace from=".emmc_U1 > .pin120" to=".emmc_U1 > .pin121" />
+    <trace from=".emmc_U1 > .pin121" to=".emmc_U1 > .pin122" />
+    <trace from=".emmc_U1 > .pin122" to=".emmc_U1 > .pin123" />
+    <trace from=".emmc_U1 > .pin123" to=".emmc_U1 > .pin124" />
+    <trace from=".emmc_U1 > .pin124" to=".emmc_U1 > .pin125" />
+    <trace from=".emmc_U1 > .pin125" to=".emmc_U1 > .pin126" />
+    <trace from=".emmc_U1 > .pin126" to=".emmc_U1 > .pin127" />
+    <trace from=".emmc_U1 > .pin127" to=".emmc_U1 > .pin128" />
+    <trace from=".emmc_U1 > .pin128" to=".emmc_U1 > .pin129" />
+    <trace from=".emmc_U1 > .pin129" to=".emmc_U1 > .pin130" />
+    <trace from=".emmc_U1 > .pin130" to=".emmc_U1 > .pin131" />
+    <trace from=".emmc_U1 > .pin131" to=".emmc_U1 > .pin132" />
+    <trace from=".emmc_U1 > .pin132" to=".emmc_U1 > .pin133" />
+    <trace from=".emmc_U1 > .pin133" to=".emmc_U1 > .pin134" />
+    <trace from=".emmc_U1 > .pin134" to=".emmc_U1 > .pin135" />
+    <trace from=".emmc_U1 > .pin135" to=".emmc_U1 > .pin136" />
+    <trace from=".emmc_U1 > .pin136" to=".emmc_U1 > .pin137" />
+    <trace from=".emmc_U1 > .pin137" to=".emmc_U1 > .pin138" />
+    <trace from=".emmc_U1 > .pin138" to=".emmc_U1 > .pin139" />
+    <trace from=".emmc_U1 > .pin139" to=".emmc_U1 > .pin140" />
+    <trace from=".emmc_U1 > .pin140" to=".emmc_U1 > .pin141" />
+    <trace from=".emmc_U1 > .pin141" to=".emmc_U1 > .pin142" />
+    <trace from=".emmc_U1 > .pin142" to=".emmc_U1 > .pin143" />
+    <trace from=".emmc_U1 > .pin143" to=".emmc_U1 > .pin144" />
+    <trace from=".emmc_U1 > .pin144" to=".emmc_U1 > .pin145" />
+    <trace from=".emmc_U1 > .pin145" to=".emmc_U1 > .pin146" />
+    <trace from=".emmc_U1 > .pin146" to=".emmc_U1 > .pin147" />
+    <trace from=".emmc_U1 > .pin147" to=".emmc_U1 > .pin148" />
+    <trace from=".emmc_U1 > .pin148" to=".emmc_U1 > .pin149" />
+    <trace from=".emmc_U1 > .pin149" to=".emmc_U1 > .pin150" />
+    <trace from=".emmc_U1 > .pin150" to=".emmc_U1 > .pin151" />
+    <trace from=".emmc_U1 > .pin151" to=".emmc_U1 > .pin152" />
+    <trace from=".emmc_U1 > .pin152" to=".emmc_U1 > .pin153" />
+    <trace from=".emmc_U1 > .pin153" to=".pmic_U1 > .pin4" />
+    <trace from=".pmic_U1 > .pin4" to=".pmic_U1 > .pin5" />
+    <trace from=".pmic_U1 > .pin5" to=".pmic_U1 > .pin6" />
+    <trace from=".hdmitx_C8 > .pin1" to=".hdmiconn_J1 > .pin12" />
+    <trace from=".hdmiconn_J1 > .pin12" to=".hdmiconn_D8 > .pin1" />
+    <trace from=".hdmitx_C7 > .pin1" to=".hdmiconn_J1 > .pin10" />
+    <trace from=".hdmiconn_J1 > .pin10" to=".hdmiconn_D7 > .pin1" />
+    <trace from=".hdmitx_C6 > .pin1" to=".hdmiconn_J1 > .pin9" />
+    <trace from=".hdmiconn_J1 > .pin9" to=".hdmiconn_D6 > .pin1" />
+    <trace from=".hdmiconn_D6 > .pin1" to=".soc_U1 > .pin92" />
+    <trace from=".hdmitx_C5 > .pin1" to=".hdmiconn_J1 > .pin7" />
+    <trace from=".hdmiconn_J1 > .pin7" to=".hdmiconn_D5 > .pin1" />
+    <trace from=".hdmiconn_D5 > .pin1" to=".soc_U1 > .pin91" />
+    <trace from=".hdmitx_C4 > .pin1" to=".hdmiconn_J1 > .pin6" />
+    <trace from=".hdmiconn_J1 > .pin6" to=".hdmiconn_D4 > .pin1" />
+    <trace from=".hdmitx_C3 > .pin1" to=".hdmiconn_J1 > .pin4" />
+    <trace from=".hdmiconn_J1 > .pin4" to=".hdmiconn_D3 > .pin1" />
+    <trace from=".hdmitx_C2 > .pin1" to=".hdmiconn_J1 > .pin3" />
+    <trace from=".hdmiconn_J1 > .pin3" to=".hdmiconn_D2 > .pin1" />
+    <trace from=".hdmitx_C1 > .pin1" to=".hdmiconn_J1 > .pin1" />
+    <trace from=".hdmiconn_J1 > .pin1" to=".hdmiconn_D1 > .pin1" />
+    <trace from=".hdmitx_C6 > .pin2" to=".hdmitx_D6 > .pin1" />
+    <trace from=".hdmitx_D6 > .pin1" to=".hdmitx_J1 > .pin9" />
+    <trace from=".hdmitx_C5 > .pin2" to=".hdmitx_D5 > .pin1" />
+    <trace from=".hdmitx_D5 > .pin1" to=".hdmitx_J1 > .pin7" />
+    <trace from=".hdmitx_C4 > .pin2" to=".hdmitx_D4 > .pin1" />
+    <trace from=".hdmitx_D4 > .pin1" to=".hdmitx_J1 > .pin6" />
+    <trace from=".hdmitx_C3 > .pin2" to=".hdmitx_D3 > .pin1" />
+    <trace from=".hdmitx_D3 > .pin1" to=".hdmitx_J1 > .pin4" />
+    <trace from=".hdmitx_C2 > .pin2" to=".hdmitx_D2 > .pin1" />
+    <trace from=".hdmitx_D2 > .pin1" to=".hdmitx_J1 > .pin3" />
+    <trace from=".hdmitx_C1 > .pin2" to=".hdmitx_D1 > .pin1" />
+    <trace from=".hdmitx_D1 > .pin1" to=".hdmitx_J1 > .pin1" />
+    <trace from=".hdmitx_C8 > .pin2" to=".hdmitx_D8 > .pin1" />
+    <trace from=".hdmitx_D8 > .pin1" to=".hdmitx_J1 > .pin12" />
+    <trace from=".hdmitx_C7 > .pin2" to=".hdmitx_D7 > .pin1" />
+    <trace from=".hdmitx_D7 > .pin1" to=".hdmitx_J1 > .pin10" />
+    <trace from=".pmic_U1 > .pin35" to=".pmic_R1 > .pin2" />
+    <trace from=".pmic_R1 > .pin2" to=".hdmitx_D9 > .pin1" />
+    <trace from=".hdmitx_D9 > .pin1" to=".hdmitx_J1 > .pin15" />
+    <trace from=".hdmitx_J1 > .pin15" to=".codec_U1 > .pin9" />
+    <trace from=".codec_U1 > .pin9" to=".codec_R1 > .pin2" />
+    <trace from=".codec_R1 > .pin2" to=".eeprom_U1 > .pin6" />
+    <trace from=".eeprom_U1 > .pin6" to=".eeprom_R1 > .pin2" />
+    <trace from=".eeprom_R1 > .pin2" to=".i2cpull_R1 > .pin2" />
+    <trace from=".i2cpull_R1 > .pin2" to=".expansion_J1 > .pin5" />
+    <trace from=".expansion_J1 > .pin5" to=".soc_U1 > .pin77" />
+    <trace from=".pmic_U1 > .pin36" to=".pmic_R2 > .pin2" />
+    <trace from=".pmic_R2 > .pin2" to=".hdmitx_D10 > .pin1" />
+    <trace from=".hdmitx_D10 > .pin1" to=".hdmitx_J1 > .pin16" />
+    <trace from=".hdmitx_J1 > .pin16" to=".codec_U1 > .pin10" />
+    <trace from=".codec_U1 > .pin10" to=".codec_R2 > .pin2" />
+    <trace from=".codec_R2 > .pin2" to=".eeprom_U1 > .pin5" />
+    <trace from=".eeprom_U1 > .pin5" to=".eeprom_R2 > .pin2" />
+    <trace from=".eeprom_R2 > .pin2" to=".i2cpull_R2 > .pin2" />
+    <trace from=".i2cpull_R2 > .pin2" to=".expansion_J1 > .pin3" />
+    <trace from=".expansion_J1 > .pin3" to=".soc_U1 > .pin78" />
+    <trace from=".inprot_U1 > .pin1" to=".inprot_R1 > .pin1" />
+    <trace from=".inprot_R1 > .pin1" to=".inprot_C1 > .pin2" />
+    <trace from=".jtag_J1 > .pin4" to=".soc_U1 > .pin85" />
+    <trace from=".jtag_J1 > .pin8" to=".soc_U1 > .pin87" />
+    <trace from=".jtag_J1 > .pin6" to=".soc_U1 > .pin88" />
+    <trace from=".jtag_J1 > .pin2" to=".soc_U1 > .pin86" />
+    <trace from=".leds_R2 > .pin2" to=".leds_D2 > .pin1" />
+    <trace from=".leds_R1 > .pin2" to=".leds_D1 > .pin1" />
+    <trace from=".magjack_J1 > .pin9" to=".magjack_R6 > .pin2" />
+    <trace from=".magjack_J1 > .pin11" to=".magjack_R1 > .pin1" />
+    <trace from=".magjack_J1 > .pin12" to=".magjack_R2 > .pin1" />
+    <trace from=".magjack_J1 > .pin13" to=".magjack_R3 > .pin1" />
+    <trace from=".magjack_J1 > .pin14" to=".magjack_R4 > .pin1" />
+    <trace from=".magjack_R1 > .pin2" to=".magjack_R2 > .pin2" />
+    <trace from=".magjack_R2 > .pin2" to=".magjack_R3 > .pin2" />
+    <trace from=".magjack_R3 > .pin2" to=".magjack_R4 > .pin2" />
+    <trace from=".magjack_R4 > .pin2" to=".magjack_C1 > .pin1" />
+    <trace from=".magjack_J1 > .pin7" to=".magjack_R5 > .pin2" />
+    <trace from=".usbcpd_J1 > .pin3" to=".usbcpd_R1 > .pin1" />
+    <trace from=".usbcpd_R1 > .pin1" to=".usbcpd_U1 > .pin1" />
+    <trace from=".usbcpd_U1 > .pin1" to=".usbcpd_U2 > .pin3" />
+    <trace from=".usbcpd_J1 > .pin11" to=".usbcpd_R2 > .pin1" />
+    <trace from=".usbcpd_R2 > .pin1" to=".usbcpd_U1 > .pin2" />
+    <trace from=".usbcpd_U1 > .pin2" to=".usbcpd_U2 > .pin4" />
+    <trace from=".pmic_U1 > .pin37" to=".pmic_R3 > .pin2" />
+    <trace from=".pmic_U1 > .pin38" to=".pmic_R4 > .pin2" />
+    <trace from=".pmic_U1 > .pin13" to=".pmic_U1 > .pin14" />
+    <trace from=".pmic_U1 > .pin14" to=".pmic_L4 > .pin1" />
+    <trace from=".pmic_U1 > .pin15" to=".pmic_U1 > .pin16" />
+    <trace from=".pmic_U1 > .pin16" to=".pmic_L5 > .pin1" />
+    <trace from=".pmic_L1 > .pin1" to=".pmic_U1 > .pin7" />
+    <trace from=".pmic_U1 > .pin7" to=".pmic_U1 > .pin8" />
+    <trace from=".pmic_U1 > .pin11" to=".pmic_U1 > .pin12" />
+    <trace from=".pmic_U1 > .pin12" to=".pmic_L3 > .pin1" />
+    <trace from=".pmic_U1 > .pin9" to=".pmic_U1 > .pin10" />
+    <trace from=".pmic_U1 > .pin10" to=".pmic_L2 > .pin1" />
+    <trace from=".pmic_U1 > .pin39" to=".pmic_R5 > .pin1" />
+    <trace from=".pmic_R5 > .pin1" to=".reset_U1 > .pin1" />
+    <trace from=".reset_U1 > .pin1" to=".reset_R1 > .pin2" />
+    <trace from=".reset_R1 > .pin2" to=".reset_SW1 > .pin1" />
+    <trace from=".reset_SW1 > .pin1" to=".soc_U1 > .pin82" />
+    <trace from=".reset_U1 > .pin5" to=".reset_C1 > .pin1" />
+    <trace from=".phy_U1 > .pin11" to=".soc_U1 > .pin67" />
+    <trace from=".phy_U1 > .pin12" to=".soc_U1 > .pin68" />
+    <trace from=".phy_U1 > .pin13" to=".phy_R3 > .pin1" />
+    <trace from=".phy_R3 > .pin1" to=".soc_U1 > .pin73" />
+    <trace from=".phy_U1 > .pin14" to=".phy_R4 > .pin1" />
+    <trace from=".phy_R4 > .pin1" to=".soc_U1 > .pin74" />
+    <trace from=".phy_U1 > .pin15" to=".phy_R5 > .pin1" />
+    <trace from=".phy_R5 > .pin1" to=".soc_U1 > .pin75" />
+    <trace from=".phy_U1 > .pin16" to=".soc_U1 > .pin76" />
+    <trace from=".phy_U1 > .pin5" to=".soc_U1 > .pin65" />
+    <trace from=".phy_U1 > .pin6" to=".soc_U1 > .pin66" />
+    <trace from=".phy_U1 > .pin7" to=".soc_U1 > .pin69" />
+    <trace from=".phy_U1 > .pin8" to=".soc_U1 > .pin70" />
+    <trace from=".phy_U1 > .pin9" to=".soc_U1 > .pin71" />
+    <trace from=".phy_U1 > .pin10" to=".soc_U1 > .pin72" />
+    <trace from=".codec_U1 > .pin5" to=".soc_U1 > .pin94" />
+    <trace from=".codec_U1 > .pin6" to=".soc_U1 > .pin95" />
+    <trace from=".codec_U1 > .pin4" to=".soc_U1 > .pin93" />
+    <trace from=".codec_U1 > .pin8" to=".soc_U1 > .pin97" />
+    <trace from=".codec_U1 > .pin7" to=".soc_U1 > .pin96" />
+    <trace from=".usdcard_J1 > .pin7" to=".expansion_J1 > .pin35" />
+    <trace from=".usdcard_J1 > .pin8" to=".expansion_J1 > .pin36" />
+    <trace from=".jtag_J1 > .pin10" to=".reset_U1 > .pin3" />
+    <trace from=".reset_U1 > .pin3" to=".soc_U1 > .pin81" />
+    <trace from=".pmic_C1 > .pin1" to=".pmic_C2 > .pin1" />
+    <trace from=".pmic_C2 > .pin1" to=".inprot_U1 > .pin3" />
+    <trace from=".inprot_U1 > .pin3" to=".buck33_U1 > .pin8" />
+    <trace from=".buck33_U1 > .pin8" to=".buck33_U1 > .pin11" />
+    <trace from=".buck33_U1 > .pin11" to=".buck33_U1 > .pin12" />
+    <trace from=".buck33_U1 > .pin12" to=".buck33_U1 > .pin13" />
+    <trace from=".buck33_U1 > .pin13" to=".buck33_C1 > .pin1" />
+    <trace from=".buck33_C1 > .pin1" to=".buck33_C2 > .pin1" />
+    <trace from=".buck33_C2 > .pin1" to=".buck33_C3 > .pin1" />
+    <trace from=".buck33_C3 > .pin1" to=".buck33_C4 > .pin1" />
+    <trace from=".buck33_C4 > .pin1" to=".buck18_U1 > .pin5" />
+    <trace from=".buck18_U1 > .pin5" to=".buck18_U1 > .pin6" />
+    <trace from=".buck18_U1 > .pin6" to=".buck18_U1 > .pin7" />
+    <trace from=".buck18_U1 > .pin7" to=".buck18_C1 > .pin1" />
+    <trace from=".buck18_C1 > .pin1" to=".buck18_C2 > .pin1" />
+    <trace from=".buck18_C2 > .pin1" to=".buck18_C3 > .pin1" />
+    <trace from=".buck18_C3 > .pin1" to=".bulk_C1 > .pin1" />
+    <trace from=".bulk_C1 > .pin1" to=".bulk_C2 > .pin1" />
+    <trace from=".bulk_C2 > .pin1" to=".hdmiconn_J1 > .pin18" />
+    <trace from=".hdmiconn_J1 > .pin18" to=".usbhost_U1 > .pin4" />
+    <trace from=".usbhost_U1 > .pin4" to=".expansion_J1 > .pin2" />
+    <trace from=".expansion_J1 > .pin2" to=".expansion_J1 > .pin4" />
+    <trace from=".expansion_J1 > .pin4" to=".pmic_U1 > .pin1" />
+    <trace from=".pmic_U1 > .pin1" to=".pmic_U1 > .pin2" />
+    <trace from=".pmic_U1 > .pin2" to=".pmic_U1 > .pin3" />
+    <trace from=".console_U1 > .pin2" to=".expansion_J1 > .pin10" />
+    <trace from=".expansion_J1 > .pin10" to=".soc_U1 > .pin80" />
+    <trace from=".console_U1 > .pin3" to=".expansion_J1 > .pin8" />
+    <trace from=".expansion_J1 > .pin8" to=".soc_U1 > .pin79" />
+    <trace from=".usbcpd_J1 > .pin2" to=".usbcpd_J1 > .pin7" />
+    <trace from=".usbcpd_J1 > .pin7" to=".usbcpd_J1 > .pin10" />
+    <trace from=".usbcpd_J1 > .pin10" to=".usbcpd_J1 > .pin15" />
+    <trace from=".usbcpd_J1 > .pin15" to=".usbcpd_U1 > .pin3" />
+    <trace from=".usbcpd_U1 > .pin3" to=".usbcpd_D1 > .pin2" />
+    <trace from=".usbcpd_D1 > .pin2" to=".inprot_U1 > .pin2" />
+    <trace from=".inprot_U1 > .pin2" to=".inprot_C1 > .pin1" />
+    <trace from=".usbcpd_J1 > .pin5" to=".usbcpd_J1 > .pin13" />
+    <trace from=".usbcpd_J1 > .pin13" to=".usbcpd_U2 > .pin2" />
+    <trace from=".usbcpd_U2 > .pin2" to=".usbhost_U2 > .pin3" />
+    <trace from=".usbhost_U2 > .pin3" to=".usbhost_U2 > .pin4" />
+    <trace from=".usbhost_U2 > .pin4" to=".usbhost_J1 > .pin2" />
+    <trace from=".usbhost_J1 > .pin2" to=".soc_U1 > .pin90" />
+    <trace from=".usbcpd_J1 > .pin4" to=".usbcpd_J1 > .pin12" />
+    <trace from=".usbcpd_J1 > .pin12" to=".usbcpd_U2 > .pin1" />
+    <trace from=".usbcpd_U2 > .pin1" to=".usbhost_U2 > .pin1" />
+    <trace from=".usbhost_U2 > .pin1" to=".usbhost_U2 > .pin6" />
+    <trace from=".usbhost_U2 > .pin6" to=".usbhost_J1 > .pin3" />
+    <trace from=".usbhost_J1 > .pin3" to=".soc_U1 > .pin89" />
+    <trace from=".usbhost_U1 > .pin1" to=".usbhost_R1 > .pin1" />
+    <trace from=".usbhost_U1 > .pin5" to=".usbhost_U2 > .pin5" />
+    <trace from=".usbhost_U2 > .pin5" to=".usbhost_J1 > .pin1" />
+    <trace from=".soc_U1 > .pin11" to=".pmic_U1 > .pin20" />
+    <trace from=".pmic_U1 > .pin20" to=".pmic_U1 > .pin41" />
+    <trace from=".pmic_U1 > .pin41" to=".pmic_L4 > .pin2" />
+    <trace from=".pmic_L4 > .pin2" to=".pmic_C9 > .pin1" />
+    <trace from=".pmic_C9 > .pin1" to=".pmic_C10 > .pin1" />
+    <trace from=".pmic_C10 > .pin1" to=".soc_U1 > .pin12" />
+    <trace from=".soc_U1 > .pin12" to=".buck18_U1 > .pin13" />
+    <trace from=".buck18_U1 > .pin13" to=".buck18_L1 > .pin2" />
+    <trace from=".buck18_L1 > .pin2" to=".buck18_C4 > .pin1" />
+    <trace from=".buck18_C4 > .pin1" to=".buck18_C5 > .pin1" />
+    <trace from=".buck18_C5 > .pin1" to=".buck18_C6 > .pin1" />
+    <trace from=".buck18_C6 > .pin1" to=".buck18_R1 > .pin1" />
+    <trace from=".buck18_R1 > .pin1" to=".ldo06_U1 > .pin1" />
+    <trace from=".ldo06_U1 > .pin1" to=".ldo06_U1 > .pin3" />
+    <trace from=".ldo06_U1 > .pin3" to=".ldo06_C1 > .pin1" />
+    <trace from=".ldo06_C1 > .pin1" to=".railcaps_C6 > .pin1" />
+    <trace from=".railcaps_C6 > .pin1" to=".railcaps_C7 > .pin1" />
+    <trace from=".railcaps_C7 > .pin1" to=".railcaps_C8 > .pin1" />
+    <trace from=".railcaps_C8 > .pin1" to=".railcaps_C9 > .pin1" />
+    <trace from=".railcaps_C9 > .pin1" to=".railcaps_C10 > .pin1" />
+    <trace from=".railcaps_C10 > .pin1" to=".phy_U1 > .pin3" />
+    <trace from=".phy_U1 > .pin3" to=".phy_R1 > .pin2" />
+    <trace from=".phy_R1 > .pin2" to=".phy_R2 > .pin2" />
+    <trace from=".phy_R2 > .pin2" to=".phy_R3 > .pin2" />
+    <trace from=".phy_R3 > .pin2" to=".socdecoup_C27 > .pin1" />
+    <trace from=".socdecoup_C27 > .pin1" to=".socdecoup_C28 > .pin1" />
+    <trace from=".socdecoup_C28 > .pin1" to=".socdecoup_C29 > .pin1" />
+    <trace from=".socdecoup_C29 > .pin1" to=".socdecoup_C30 > .pin1" />
+    <trace from=".socdecoup_C30 > .pin1" to=".socdecoup_C31 > .pin1" />
+    <trace from=".socdecoup_C31 > .pin1" to=".socdecoup_C32 > .pin1" />
+    <trace from=".socdecoup_C32 > .pin1" to=".socdecoup_C33 > .pin1" />
+    <trace from=".socdecoup_C33 > .pin1" to=".socdecoup_C34 > .pin1" />
+    <trace from=".socdecoup_C34 > .pin1" to=".emmc_U1 > .pin2" />
+    <trace from=".emmc_U1 > .pin2" to=".soc_U1 > .pin10" />
+    <trace from=".pmic_U1 > .pin21" to=".pmic_U1 > .pin40" />
+    <trace from=".pmic_U1 > .pin40" to=".pmic_L5 > .pin2" />
+    <trace from=".pmic_L5 > .pin2" to=".pmic_C11 > .pin1" />
+    <trace from=".pmic_C11 > .pin1" to=".pmic_C12 > .pin1" />
+    <trace from=".pmic_C12 > .pin1" to=".pmic_R1 > .pin1" />
+    <trace from=".pmic_R1 > .pin1" to=".pmic_R2 > .pin1" />
+    <trace from=".pmic_R2 > .pin1" to=".pmic_R3 > .pin1" />
+    <trace from=".pmic_R3 > .pin1" to=".pmic_R4 > .pin1" />
+    <trace from=".pmic_R4 > .pin1" to=".buck33_U1 > .pin10" />
+    <trace from=".buck33_U1 > .pin10" to=".soc_U1 > .pin13" />
+    <trace from=".soc_U1 > .pin13" to=".buck33_L1 > .pin2" />
+    <trace from=".buck33_L1 > .pin2" to=".buck33_C5 > .pin1" />
+    <trace from=".buck33_C5 > .pin1" to=".buck33_C6 > .pin1" />
+    <trace from=".buck33_C6 > .pin1" to=".buck33_R1 > .pin1" />
+    <trace from=".buck33_R1 > .pin1" to=".buck33_C7 > .pin1" />
+    <trace from=".buck33_C7 > .pin1" to=".ldortc_U1 > .pin1" />
+    <trace from=".ldortc_U1 > .pin1" to=".ldortc_U1 > .pin3" />
+    <trace from=".ldortc_U1 > .pin3" to=".ldortc_C1 > .pin1" />
+    <trace from=".ldortc_C1 > .pin1" to=".ldoaudio_U1 > .pin3" />
+    <trace from=".ldoaudio_U1 > .pin3" to=".ldoaudio_U1 > .pin5" />
+    <trace from=".ldoaudio_U1 > .pin5" to=".ldoaudio_C1 > .pin1" />
+    <trace from=".ldoaudio_C1 > .pin1" to=".ldohdmi_U1 > .pin1" />
+    <trace from=".ldohdmi_U1 > .pin1" to=".ldohdmi_U1 > .pin3" />
+    <trace from=".ldohdmi_U1 > .pin3" to=".ldohdmi_C1 > .pin1" />
+    <trace from=".ldohdmi_C1 > .pin1" to=".soc_U1 > .pin14" />
+    <trace from=".soc_U1 > .pin14" to=".railcaps_C1 > .pin1" />
+    <trace from=".railcaps_C1 > .pin1" to=".railcaps_C2 > .pin1" />
+    <trace from=".railcaps_C2 > .pin1" to=".railcaps_C3 > .pin1" />
+    <trace from=".railcaps_C3 > .pin1" to=".railcaps_C4 > .pin1" />
+    <trace from=".railcaps_C4 > .pin1" to=".railcaps_C5 > .pin1" />
+    <trace from=".railcaps_C5 > .pin1" to=".phy_U1 > .pin1" />
+    <trace from=".phy_U1 > .pin1" to=".phy_U1 > .pin2" />
+    <trace from=".phy_U1 > .pin2" to=".magjack_J1 > .pin5" />
+    <trace from=".magjack_J1 > .pin5" to=".magjack_J1 > .pin6" />
+    <trace from=".magjack_J1 > .pin6" to=".soc_U1 > .pin15" />
+    <trace from=".soc_U1 > .pin15" to=".magjack_R5 > .pin1" />
+    <trace from=".magjack_R5 > .pin1" to=".magjack_R6 > .pin1" />
+    <trace from=".magjack_R6 > .pin1" to=".usdcard_J1 > .pin4" />
+    <trace from=".usdcard_J1 > .pin4" to=".console_U1 > .pin4" />
+    <trace from=".console_U1 > .pin4" to=".console_U1 > .pin9" />
+    <trace from=".console_U1 > .pin9" to=".console_U1 > .pin16" />
+    <trace from=".console_U1 > .pin16" to=".jtag_J1 > .pin1" />
+    <trace from=".jtag_J1 > .pin1" to=".bootsel_SW1 > .pin3" />
+    <trace from=".bootsel_SW1 > .pin3" to=".reset_U1 > .pin4" />
+    <trace from=".reset_U1 > .pin4" to=".reset_R1 > .pin1" />
+    <trace from=".reset_R1 > .pin1" to=".eeprom_U1 > .pin8" />
+    <trace from=".eeprom_U1 > .pin8" to=".eeprom_R1 > .pin1" />
+    <trace from=".eeprom_R1 > .pin1" to=".eeprom_R2 > .pin1" />
+    <trace from=".eeprom_R2 > .pin1" to=".i2cpull_R1 > .pin1" />
+    <trace from=".i2cpull_R1 > .pin1" to=".i2cpull_R2 > .pin1" />
+    <trace from=".i2cpull_R2 > .pin1" to=".leds_R1 > .pin1" />
+    <trace from=".leds_R1 > .pin1" to=".leds_R2 > .pin1" />
+    <trace from=".leds_R2 > .pin1" to=".expansion_J1 > .pin1" />
+    <trace from=".expansion_J1 > .pin1" to=".expansion_J1 > .pin17" />
+    <trace from=".expansion_J1 > .pin17" to=".socdecoup_C35 > .pin1" />
+    <trace from=".socdecoup_C35 > .pin1" to=".socdecoup_C36 > .pin1" />
+    <trace from=".socdecoup_C36 > .pin1" to=".socdecoup_C37 > .pin1" />
+    <trace from=".socdecoup_C37 > .pin1" to=".socdecoup_C38 > .pin1" />
+    <trace from=".socdecoup_C38 > .pin1" to=".socdecoup_C39 > .pin1" />
+    <trace from=".socdecoup_C39 > .pin1" to=".socdecoup_C40 > .pin1" />
+    <trace from=".socdecoup_C40 > .pin1" to=".emmc_U1 > .pin1" />
+    <trace from=".soc_U1 > .pin1" to=".soc_U1 > .pin2" />
+    <trace from=".soc_U1 > .pin2" to=".pmic_U1 > .pin17" />
+    <trace from=".pmic_U1 > .pin17" to=".pmic_L1 > .pin2" />
+    <trace from=".pmic_L1 > .pin2" to=".pmic_C3 > .pin1" />
+    <trace from=".pmic_C3 > .pin1" to=".pmic_C4 > .pin1" />
+    <trace from=".pmic_C4 > .pin1" to=".soc_U1 > .pin3" />
+    <trace from=".soc_U1 > .pin3" to=".socdecoup_C1 > .pin1" />
+    <trace from=".socdecoup_C1 > .pin1" to=".socdecoup_C2 > .pin1" />
+    <trace from=".socdecoup_C2 > .pin1" to=".socdecoup_C3 > .pin1" />
+    <trace from=".socdecoup_C3 > .pin1" to=".socdecoup_C4 > .pin1" />
+    <trace from=".socdecoup_C4 > .pin1" to=".socdecoup_C5 > .pin1" />
+    <trace from=".socdecoup_C5 > .pin1" to=".socdecoup_C6 > .pin1" />
+    <trace from=".socdecoup_C6 > .pin1" to=".socdecoup_C7 > .pin1" />
+    <trace from=".socdecoup_C7 > .pin1" to=".socdecoup_C8 > .pin1" />
+    <trace from=".ldoaudio_U1 > .pin2" to=".ldoaudio_C2 > .pin1" />
+    <trace from=".ldoaudio_C2 > .pin1" to=".codec_U1 > .pin1" />
+    <trace from=".codec_U1 > .pin1" to=".codec_U1 > .pin2" />
+    <trace from=".codec_U1 > .pin2" to=".codec_U1 > .pin23" />
+    <trace from=".codec_U1 > .pin23" to=".codec_R1 > .pin1" />
+    <trace from=".codec_R1 > .pin1" to=".codec_R2 > .pin1" />
+    <trace from=".codec_R2 > .pin1" to=".codec_R3 > .pin1" />
+    <trace from=".codec_R3 > .pin1" to=".codec_C1 > .pin1" />
+    <trace from=".codec_C1 > .pin1" to=".codec_C2 > .pin1" />
+    <trace from=".codec_C2 > .pin1" to=".codec_C3 > .pin1" />
+    <trace from=".ldo06_U1 > .pin5" to=".ldo06_C2 > .pin1" />
+    <trace from=".ldo06_C2 > .pin1" to=".ddr_U1 > .pin37" />
+    <trace from=".ddr_U1 > .pin37" to=".ddr_U1 > .pin38" />
+    <trace from=".ddr_U1 > .pin38" to=".ddr_U1 > .pin39" />
+    <trace from=".ddr_U1 > .pin39" to=".ddrterm_R3 > .pin1" />
+    <trace from=".ddrterm_R3 > .pin1" to=".ddrdecoup_C4 > .pin1" />
+    <trace from=".ddrdecoup_C4 > .pin1" to=".ddrdecoup_C5 > .pin1" />
+    <trace from=".ddrdecoup_C5 > .pin1" to=".ddrdecoup_C6 > .pin1" />
+    <trace from=".pmic_U1 > .pin19" to=".pmic_L3 > .pin2" />
+    <trace from=".pmic_L3 > .pin2" to=".pmic_C7 > .pin1" />
+    <trace from=".pmic_C7 > .pin1" to=".pmic_C8 > .pin1" />
+    <trace from=".pmic_C8 > .pin1" to=".socdecoup_C17 > .pin1" />
+    <trace from=".socdecoup_C17 > .pin1" to=".socdecoup_C18 > .pin1" />
+    <trace from=".socdecoup_C18 > .pin1" to=".socdecoup_C19 > .pin1" />
+    <trace from=".socdecoup_C19 > .pin1" to=".socdecoup_C20 > .pin1" />
+    <trace from=".socdecoup_C20 > .pin1" to=".socdecoup_C21 > .pin1" />
+    <trace from=".socdecoup_C21 > .pin1" to=".socdecoup_C22 > .pin1" />
+    <trace from=".socdecoup_C22 > .pin1" to=".socdecoup_C23 > .pin1" />
+    <trace from=".socdecoup_C23 > .pin1" to=".socdecoup_C24 > .pin1" />
+    <trace from=".socdecoup_C24 > .pin1" to=".socdecoup_C25 > .pin1" />
+    <trace from=".socdecoup_C25 > .pin1" to=".socdecoup_C26 > .pin1" />
+    <trace from=".socdecoup_C26 > .pin1" to=".soc_U1 > .pin7" />
+    <trace from=".soc_U1 > .pin7" to=".ddr_U1 > .pin34" />
+    <trace from=".ddr_U1 > .pin34" to=".ddr_U1 > .pin35" />
+    <trace from=".ddr_U1 > .pin35" to=".ddr_U1 > .pin36" />
+    <trace from=".ddr_U1 > .pin36" to=".soc_U1 > .pin8" />
+    <trace from=".soc_U1 > .pin8" to=".soc_U1 > .pin9" />
+    <trace from=".soc_U1 > .pin9" to=".ddrterm_R1 > .pin1" />
+    <trace from=".ddrterm_R1 > .pin1" to=".ddrdecoup_C1 > .pin1" />
+    <trace from=".ddrdecoup_C1 > .pin1" to=".ddrdecoup_C2 > .pin1" />
+    <trace from=".ddrdecoup_C2 > .pin1" to=".ddrdecoup_C3 > .pin1" />
+    <trace from=".ldohdmi_U1 > .pin5" to=".ldohdmi_C2 > .pin1" />
+    <trace from=".ldortc_U1 > .pin5" to=".ldortc_C2 > .pin1" />
+    <trace from=".pmic_U1 > .pin18" to=".pmic_L2 > .pin2" />
+    <trace from=".pmic_L2 > .pin2" to=".pmic_C5 > .pin1" />
+    <trace from=".pmic_C5 > .pin1" to=".pmic_C6 > .pin1" />
+    <trace from=".pmic_C6 > .pin1" to=".soc_U1 > .pin4" />
+    <trace from=".soc_U1 > .pin4" to=".soc_U1 > .pin5" />
+    <trace from=".soc_U1 > .pin5" to=".soc_U1 > .pin6" />
+    <trace from=".soc_U1 > .pin6" to=".socdecoup_C9 > .pin1" />
+    <trace from=".socdecoup_C9 > .pin1" to=".socdecoup_C10 > .pin1" />
+    <trace from=".socdecoup_C10 > .pin1" to=".socdecoup_C11 > .pin1" />
+    <trace from=".socdecoup_C11 > .pin1" to=".socdecoup_C12 > .pin1" />
+    <trace from=".socdecoup_C12 > .pin1" to=".socdecoup_C13 > .pin1" />
+    <trace from=".socdecoup_C13 > .pin1" to=".socdecoup_C14 > .pin1" />
+    <trace from=".socdecoup_C14 > .pin1" to=".socdecoup_C15 > .pin1" />
+    <trace from=".socdecoup_C15 > .pin1" to=".socdecoup_C16 > .pin1" />
+    <trace from=".xtal24_Y1 > .pin1" to=".xtal24_C1 > .pin1" />
+    <trace from=".xtal24_C1 > .pin1" to=".soc_U1 > .pin98" />
+    <trace from=".xtal24_Y1 > .pin2" to=".xtal24_C2 > .pin1" />
+    <trace from=".xtal24_C2 > .pin1" to=".soc_U1 > .pin99" />
+    <trace from=".rtcxtal_Y1 > .pin1" to=".rtcxtal_C1 > .pin1" />
+    <trace from=".rtcxtal_Y1 > .pin2" to=".rtcxtal_C2 > .pin1" />
+  </board>
+)

--- a/tests/repros/repro-large-weighted-connections/pack-input.json
+++ b/tests/repros/repro-large-weighted-connections/pack-input.json
@@ -1,0 +1,29173 @@
+{
+  "components": [
+    {
+      "componentId": "pcb_component_0",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_0",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_2",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_3",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_4",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_5",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_6",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_7",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_8",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_9",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_10",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_11",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_12",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_13",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_14",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_15",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_16",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_17",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_18",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_19",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_20",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_21",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_22",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": -8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_23",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_24",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_25",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_26",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net12",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_27",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_28",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net14",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_29",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_30",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net16",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_31",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_32",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net18",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_33",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_34",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_35",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_36",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net22",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_37",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_38",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_39",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_40",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_41",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_42",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_43",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net12",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_44",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_45",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net14",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": -8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_46",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net32",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_47",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net33",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_48",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net34",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_49",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net35",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_50",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_51",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net37",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_52",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net38",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_53",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net39",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_54",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net40",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_55",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net41",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_56",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net42",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_57",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net43",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_58",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net44",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_59",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_60",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net46",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_61",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net47",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_62",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net48",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_63",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net49",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_64",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net50",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_65",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net51",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_66",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net52",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_67",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net53",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_68",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net54",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": -7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_69",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net55",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_70",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net56",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_71",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net57",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_72",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net58",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_73",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net59",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_74",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net60",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_75",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net61",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_76",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_77",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_78",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_79",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_80",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net66",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_81",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net67",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_82",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net68",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_83",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net69",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_84",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net70",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_85",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net71",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_86",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net72",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_87",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net73",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_88",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net74",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_89",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net75",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_90",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net76",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_91",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net77",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": -6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_92",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net78",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_93",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net79",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_94",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net80",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_95",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net81",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_96",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net82",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_97",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net83",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_98",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net84",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_99",
+          "networkId": "unnamed0",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_100",
+          "networkId": "unnamed1",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_101",
+          "networkId": "unnamed2",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_102",
+          "networkId": "unnamed3",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_103",
+          "networkId": "unnamed4",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_104",
+          "networkId": "unnamed5",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_105",
+          "networkId": "unnamed6",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_106",
+          "networkId": "unnamed7",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_107",
+          "networkId": "unnamed8",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_108",
+          "networkId": "unnamed9",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_109",
+          "networkId": "unnamed10",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_110",
+          "networkId": "unnamed11",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_111",
+          "networkId": "unnamed12",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_112",
+          "networkId": "unnamed13",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_113",
+          "networkId": "unnamed14",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_114",
+          "networkId": "unnamed15",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_115",
+          "networkId": "unnamed16",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_116",
+          "networkId": "unnamed17",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_117",
+          "networkId": "unnamed18",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_118",
+          "networkId": "unnamed19",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_119",
+          "networkId": "unnamed20",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_120",
+          "networkId": "unnamed21",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_121",
+          "networkId": "unnamed22",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_122",
+          "networkId": "unnamed23",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_123",
+          "networkId": "unnamed24",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_124",
+          "networkId": "unnamed25",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_125",
+          "networkId": "unnamed26",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_126",
+          "networkId": "unnamed27",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_127",
+          "networkId": "unnamed28",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_128",
+          "networkId": "unnamed29",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_129",
+          "networkId": "unnamed30",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_130",
+          "networkId": "unnamed31",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_131",
+          "networkId": "unnamed32",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_132",
+          "networkId": "unnamed33",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_133",
+          "networkId": "unnamed34",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_134",
+          "networkId": "unnamed35",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_135",
+          "networkId": "unnamed36",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_136",
+          "networkId": "unnamed37",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_137",
+          "networkId": "unnamed38",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_138",
+          "networkId": "unnamed39",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_139",
+          "networkId": "unnamed40",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_140",
+          "networkId": "unnamed41",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_141",
+          "networkId": "unnamed42",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_142",
+          "networkId": "unnamed43",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_143",
+          "networkId": "unnamed44",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_144",
+          "networkId": "unnamed45",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_145",
+          "networkId": "unnamed46",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_146",
+          "networkId": "unnamed47",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_147",
+          "networkId": "unnamed48",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_148",
+          "networkId": "unnamed49",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_149",
+          "networkId": "unnamed50",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_150",
+          "networkId": "unnamed51",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_151",
+          "networkId": "unnamed52",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_152",
+          "networkId": "unnamed53",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_153",
+          "networkId": "unnamed54",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_154",
+          "networkId": "unnamed55",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_155",
+          "networkId": "unnamed56",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_156",
+          "networkId": "unnamed57",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_157",
+          "networkId": "unnamed58",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_158",
+          "networkId": "unnamed59",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_159",
+          "networkId": "unnamed60",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_160",
+          "networkId": "unnamed61",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_161",
+          "networkId": "unnamed62",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_162",
+          "networkId": "unnamed63",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_163",
+          "networkId": "unnamed64",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_164",
+          "networkId": "unnamed65",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_165",
+          "networkId": "unnamed66",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_166",
+          "networkId": "unnamed67",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_167",
+          "networkId": "unnamed68",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_168",
+          "networkId": "unnamed69",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_169",
+          "networkId": "unnamed70",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_170",
+          "networkId": "unnamed71",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_171",
+          "networkId": "unnamed72",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_172",
+          "networkId": "unnamed73",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_173",
+          "networkId": "unnamed74",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_174",
+          "networkId": "unnamed75",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_175",
+          "networkId": "unnamed76",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_176",
+          "networkId": "unnamed77",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_177",
+          "networkId": "unnamed78",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_178",
+          "networkId": "unnamed79",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_179",
+          "networkId": "unnamed80",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_180",
+          "networkId": "unnamed81",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_181",
+          "networkId": "unnamed82",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_182",
+          "networkId": "unnamed83",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_183",
+          "networkId": "unnamed84",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_184",
+          "networkId": "unnamed85",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_185",
+          "networkId": "unnamed86",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_186",
+          "networkId": "unnamed87",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_187",
+          "networkId": "unnamed88",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_188",
+          "networkId": "unnamed89",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_189",
+          "networkId": "unnamed90",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_190",
+          "networkId": "unnamed91",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_191",
+          "networkId": "unnamed92",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_192",
+          "networkId": "unnamed93",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_193",
+          "networkId": "unnamed94",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_194",
+          "networkId": "unnamed95",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_195",
+          "networkId": "unnamed96",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_196",
+          "networkId": "unnamed97",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_197",
+          "networkId": "unnamed98",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_198",
+          "networkId": "unnamed99",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_199",
+          "networkId": "unnamed100",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_200",
+          "networkId": "unnamed101",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_201",
+          "networkId": "unnamed102",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_202",
+          "networkId": "unnamed103",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_203",
+          "networkId": "unnamed104",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_204",
+          "networkId": "unnamed105",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_205",
+          "networkId": "unnamed106",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_206",
+          "networkId": "unnamed107",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_207",
+          "networkId": "unnamed108",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_208",
+          "networkId": "unnamed109",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_209",
+          "networkId": "unnamed110",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_210",
+          "networkId": "unnamed111",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_211",
+          "networkId": "unnamed112",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_212",
+          "networkId": "unnamed113",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_213",
+          "networkId": "unnamed114",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_214",
+          "networkId": "unnamed115",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_215",
+          "networkId": "unnamed116",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_216",
+          "networkId": "unnamed117",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_217",
+          "networkId": "unnamed118",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_218",
+          "networkId": "unnamed119",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_219",
+          "networkId": "unnamed120",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_220",
+          "networkId": "unnamed121",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_221",
+          "networkId": "unnamed122",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_222",
+          "networkId": "unnamed123",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_223",
+          "networkId": "unnamed124",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_224",
+          "networkId": "unnamed125",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_225",
+          "networkId": "unnamed126",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_226",
+          "networkId": "unnamed127",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_227",
+          "networkId": "unnamed128",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_228",
+          "networkId": "unnamed129",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_229",
+          "networkId": "unnamed130",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_230",
+          "networkId": "unnamed131",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_231",
+          "networkId": "unnamed132",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_232",
+          "networkId": "unnamed133",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_233",
+          "networkId": "unnamed134",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_234",
+          "networkId": "unnamed135",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_235",
+          "networkId": "unnamed136",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_236",
+          "networkId": "unnamed137",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_237",
+          "networkId": "unnamed138",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_238",
+          "networkId": "unnamed139",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_239",
+          "networkId": "unnamed140",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_240",
+          "networkId": "unnamed141",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_241",
+          "networkId": "unnamed142",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_242",
+          "networkId": "unnamed143",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_243",
+          "networkId": "unnamed144",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_244",
+          "networkId": "unnamed145",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_245",
+          "networkId": "unnamed146",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_246",
+          "networkId": "unnamed147",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_247",
+          "networkId": "unnamed148",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_248",
+          "networkId": "unnamed149",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_249",
+          "networkId": "unnamed150",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_250",
+          "networkId": "unnamed151",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_251",
+          "networkId": "unnamed152",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_252",
+          "networkId": "unnamed153",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_253",
+          "networkId": "unnamed154",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_254",
+          "networkId": "unnamed155",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_255",
+          "networkId": "unnamed156",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_256",
+          "networkId": "unnamed157",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_257",
+          "networkId": "unnamed158",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_258",
+          "networkId": "unnamed159",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_259",
+          "networkId": "unnamed160",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_260",
+          "networkId": "unnamed161",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_261",
+          "networkId": "unnamed162",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_262",
+          "networkId": "unnamed163",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_263",
+          "networkId": "unnamed164",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_264",
+          "networkId": "unnamed165",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_265",
+          "networkId": "unnamed166",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_266",
+          "networkId": "unnamed167",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_267",
+          "networkId": "unnamed168",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_268",
+          "networkId": "unnamed169",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_269",
+          "networkId": "unnamed170",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_270",
+          "networkId": "unnamed171",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_271",
+          "networkId": "unnamed172",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_272",
+          "networkId": "unnamed173",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_273",
+          "networkId": "unnamed174",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_274",
+          "networkId": "unnamed175",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_275",
+          "networkId": "unnamed176",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_276",
+          "networkId": "unnamed177",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_277",
+          "networkId": "unnamed178",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_278",
+          "networkId": "unnamed179",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_279",
+          "networkId": "unnamed180",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_280",
+          "networkId": "unnamed181",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_281",
+          "networkId": "unnamed182",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_282",
+          "networkId": "unnamed183",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_283",
+          "networkId": "unnamed184",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_284",
+          "networkId": "unnamed185",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_285",
+          "networkId": "unnamed186",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_286",
+          "networkId": "unnamed187",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_287",
+          "networkId": "unnamed188",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_288",
+          "networkId": "unnamed189",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_289",
+          "networkId": "unnamed190",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_290",
+          "networkId": "unnamed191",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_291",
+          "networkId": "unnamed192",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_292",
+          "networkId": "unnamed193",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_293",
+          "networkId": "unnamed194",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_294",
+          "networkId": "unnamed195",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_295",
+          "networkId": "unnamed196",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_296",
+          "networkId": "unnamed197",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_297",
+          "networkId": "unnamed198",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_298",
+          "networkId": "unnamed199",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_299",
+          "networkId": "unnamed200",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_300",
+          "networkId": "unnamed201",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_301",
+          "networkId": "unnamed202",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_302",
+          "networkId": "unnamed203",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_303",
+          "networkId": "unnamed204",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_304",
+          "networkId": "unnamed205",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_305",
+          "networkId": "unnamed206",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_306",
+          "networkId": "unnamed207",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_307",
+          "networkId": "unnamed208",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_308",
+          "networkId": "unnamed209",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_309",
+          "networkId": "unnamed210",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_310",
+          "networkId": "unnamed211",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_311",
+          "networkId": "unnamed212",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_312",
+          "networkId": "unnamed213",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_313",
+          "networkId": "unnamed214",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_314",
+          "networkId": "unnamed215",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_315",
+          "networkId": "unnamed216",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_316",
+          "networkId": "unnamed217",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_317",
+          "networkId": "unnamed218",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_318",
+          "networkId": "unnamed219",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_319",
+          "networkId": "unnamed220",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_320",
+          "networkId": "unnamed221",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_321",
+          "networkId": "unnamed222",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_322",
+          "networkId": "unnamed223",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_323",
+          "networkId": "unnamed224",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_324",
+          "networkId": "unnamed225",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_325",
+          "networkId": "unnamed226",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_326",
+          "networkId": "unnamed227",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_327",
+          "networkId": "unnamed228",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_328",
+          "networkId": "unnamed229",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_329",
+          "networkId": "unnamed230",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_330",
+          "networkId": "unnamed231",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_331",
+          "networkId": "unnamed232",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_332",
+          "networkId": "unnamed233",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_333",
+          "networkId": "unnamed234",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_334",
+          "networkId": "unnamed235",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_335",
+          "networkId": "unnamed236",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_336",
+          "networkId": "unnamed237",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_337",
+          "networkId": "unnamed238",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_338",
+          "networkId": "unnamed239",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_339",
+          "networkId": "unnamed240",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_340",
+          "networkId": "unnamed241",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_341",
+          "networkId": "unnamed242",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_342",
+          "networkId": "unnamed243",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_343",
+          "networkId": "unnamed244",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_344",
+          "networkId": "unnamed245",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_345",
+          "networkId": "unnamed246",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_346",
+          "networkId": "unnamed247",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_347",
+          "networkId": "unnamed248",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_348",
+          "networkId": "unnamed249",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_349",
+          "networkId": "unnamed250",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_350",
+          "networkId": "unnamed251",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_351",
+          "networkId": "unnamed252",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_352",
+          "networkId": "unnamed253",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_353",
+          "networkId": "unnamed254",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_354",
+          "networkId": "unnamed255",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_355",
+          "networkId": "unnamed256",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_356",
+          "networkId": "unnamed257",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_357",
+          "networkId": "unnamed258",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_358",
+          "networkId": "unnamed259",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_359",
+          "networkId": "unnamed260",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_360",
+          "networkId": "unnamed261",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_361",
+          "networkId": "unnamed262",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_362",
+          "networkId": "unnamed263",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_363",
+          "networkId": "unnamed264",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_364",
+          "networkId": "unnamed265",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_365",
+          "networkId": "unnamed266",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_366",
+          "networkId": "unnamed267",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_367",
+          "networkId": "unnamed268",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_368",
+          "networkId": "unnamed269",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_369",
+          "networkId": "unnamed270",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_370",
+          "networkId": "unnamed271",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_371",
+          "networkId": "unnamed272",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_372",
+          "networkId": "unnamed273",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_373",
+          "networkId": "unnamed274",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_374",
+          "networkId": "unnamed275",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_375",
+          "networkId": "unnamed276",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_376",
+          "networkId": "unnamed277",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_377",
+          "networkId": "unnamed278",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_378",
+          "networkId": "unnamed279",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_379",
+          "networkId": "unnamed280",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_380",
+          "networkId": "unnamed281",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_381",
+          "networkId": "unnamed282",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_382",
+          "networkId": "unnamed283",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_383",
+          "networkId": "unnamed284",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_384",
+          "networkId": "unnamed285",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_385",
+          "networkId": "unnamed286",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_386",
+          "networkId": "unnamed287",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_387",
+          "networkId": "unnamed288",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_388",
+          "networkId": "unnamed289",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_389",
+          "networkId": "unnamed290",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_390",
+          "networkId": "unnamed291",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_391",
+          "networkId": "unnamed292",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_392",
+          "networkId": "unnamed293",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_393",
+          "networkId": "unnamed294",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_394",
+          "networkId": "unnamed295",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_395",
+          "networkId": "unnamed296",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_396",
+          "networkId": "unnamed297",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_397",
+          "networkId": "unnamed298",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_398",
+          "networkId": "unnamed299",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_399",
+          "networkId": "unnamed300",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_400",
+          "networkId": "unnamed301",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_401",
+          "networkId": "unnamed302",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_402",
+          "networkId": "unnamed303",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_403",
+          "networkId": "unnamed304",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_404",
+          "networkId": "unnamed305",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_405",
+          "networkId": "unnamed306",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_406",
+          "networkId": "unnamed307",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_407",
+          "networkId": "unnamed308",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_408",
+          "networkId": "unnamed309",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_409",
+          "networkId": "unnamed310",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_410",
+          "networkId": "unnamed311",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_411",
+          "networkId": "unnamed312",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_412",
+          "networkId": "unnamed313",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_413",
+          "networkId": "unnamed314",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_414",
+          "networkId": "unnamed315",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_415",
+          "networkId": "unnamed316",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_416",
+          "networkId": "unnamed317",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_417",
+          "networkId": "unnamed318",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_418",
+          "networkId": "unnamed319",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_419",
+          "networkId": "unnamed320",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_420",
+          "networkId": "unnamed321",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_421",
+          "networkId": "unnamed322",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_422",
+          "networkId": "unnamed323",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_423",
+          "networkId": "unnamed324",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_424",
+          "networkId": "unnamed325",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_425",
+          "networkId": "unnamed326",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_426",
+          "networkId": "unnamed327",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_427",
+          "networkId": "unnamed328",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_428",
+          "networkId": "unnamed329",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_429",
+          "networkId": "unnamed330",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_430",
+          "networkId": "unnamed331",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_431",
+          "networkId": "unnamed332",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_432",
+          "networkId": "unnamed333",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_433",
+          "networkId": "unnamed334",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_434",
+          "networkId": "unnamed335",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_435",
+          "networkId": "unnamed336",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_436",
+          "networkId": "unnamed337",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_437",
+          "networkId": "unnamed338",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_438",
+          "networkId": "unnamed339",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_439",
+          "networkId": "unnamed340",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_440",
+          "networkId": "unnamed341",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_441",
+          "networkId": "unnamed342",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_442",
+          "networkId": "unnamed343",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_443",
+          "networkId": "unnamed344",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_444",
+          "networkId": "unnamed345",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_445",
+          "networkId": "unnamed346",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_446",
+          "networkId": "unnamed347",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_447",
+          "networkId": "unnamed348",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_448",
+          "networkId": "unnamed349",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_449",
+          "networkId": "unnamed350",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_450",
+          "networkId": "unnamed351",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_451",
+          "networkId": "unnamed352",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_452",
+          "networkId": "unnamed353",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_453",
+          "networkId": "unnamed354",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_454",
+          "networkId": "unnamed355",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_455",
+          "networkId": "unnamed356",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_456",
+          "networkId": "unnamed357",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_457",
+          "networkId": "unnamed358",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_458",
+          "networkId": "unnamed359",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_459",
+          "networkId": "unnamed360",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": 6.4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_460",
+          "networkId": "unnamed361",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_461",
+          "networkId": "unnamed362",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_462",
+          "networkId": "unnamed363",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_463",
+          "networkId": "unnamed364",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_464",
+          "networkId": "unnamed365",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_465",
+          "networkId": "unnamed366",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_466",
+          "networkId": "unnamed367",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_467",
+          "networkId": "unnamed368",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_468",
+          "networkId": "unnamed369",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_469",
+          "networkId": "unnamed370",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_470",
+          "networkId": "unnamed371",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_471",
+          "networkId": "unnamed372",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_472",
+          "networkId": "unnamed373",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_473",
+          "networkId": "unnamed374",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_474",
+          "networkId": "unnamed375",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_475",
+          "networkId": "unnamed376",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_476",
+          "networkId": "unnamed377",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_477",
+          "networkId": "unnamed378",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_478",
+          "networkId": "unnamed379",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_479",
+          "networkId": "unnamed380",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_480",
+          "networkId": "unnamed381",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_481",
+          "networkId": "unnamed382",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_482",
+          "networkId": "unnamed383",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": 7.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_483",
+          "networkId": "unnamed384",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_484",
+          "networkId": "unnamed385",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_485",
+          "networkId": "unnamed386",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_486",
+          "networkId": "unnamed387",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_487",
+          "networkId": "unnamed388",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_488",
+          "networkId": "unnamed389",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_489",
+          "networkId": "unnamed390",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_490",
+          "networkId": "unnamed391",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_491",
+          "networkId": "unnamed392",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_492",
+          "networkId": "unnamed393",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_493",
+          "networkId": "unnamed394",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_494",
+          "networkId": "unnamed395",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_495",
+          "networkId": "unnamed396",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_496",
+          "networkId": "unnamed397",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_497",
+          "networkId": "unnamed398",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_498",
+          "networkId": "unnamed399",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_499",
+          "networkId": "unnamed400",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_500",
+          "networkId": "unnamed401",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_501",
+          "networkId": "unnamed402",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_502",
+          "networkId": "unnamed403",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_503",
+          "networkId": "unnamed404",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_504",
+          "networkId": "unnamed405",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_505",
+          "networkId": "unnamed406",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": 8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_506",
+          "networkId": "unnamed407",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8.8,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_507",
+          "networkId": "unnamed408",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -8,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_508",
+          "networkId": "unnamed409",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -7.2,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_509",
+          "networkId": "unnamed410",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -6.4,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_510",
+          "networkId": "unnamed411",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_511",
+          "networkId": "unnamed412",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_512",
+          "networkId": "unnamed413",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_513",
+          "networkId": "unnamed414",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_514",
+          "networkId": "unnamed415",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_515",
+          "networkId": "unnamed416",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_516",
+          "networkId": "unnamed417",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_517",
+          "networkId": "unnamed418",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_518",
+          "networkId": "unnamed419",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_519",
+          "networkId": "unnamed420",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_520",
+          "networkId": "unnamed421",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_521",
+          "networkId": "unnamed422",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_522",
+          "networkId": "unnamed423",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_523",
+          "networkId": "unnamed424",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_524",
+          "networkId": "unnamed425",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_525",
+          "networkId": "unnamed426",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 6.4,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_526",
+          "networkId": "unnamed427",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 7.2,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_527",
+          "networkId": "unnamed428",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_528",
+          "networkId": "unnamed429",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 8.8,
+            "y": 8.8
+          }
+        },
+        {
+          "padId": "pcb_component_0-inner",
+          "networkId": "pcb_component_0-inner",
+          "type": "rect",
+          "size": {
+            "x": 17.977952755905513,
+            "y": 17.977952755905513
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 21.407952755905512,
+        "height": 21.507952755905514
+      }
+    },
+    {
+      "componentId": "pcb_component_1",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_529",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_530",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_1-inner",
+          "networkId": "pcb_component_1-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_2",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_531",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_532",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_2-inner",
+          "networkId": "pcb_component_2-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_3",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_533",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_534",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_3-inner",
+          "networkId": "pcb_component_3-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_4",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_535",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_536",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_4-inner",
+          "networkId": "pcb_component_4-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_5",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_537",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_538",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_5-inner",
+          "networkId": "pcb_component_5-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_6",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_539",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_540",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_6-inner",
+          "networkId": "pcb_component_6-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_7",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_541",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_542",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_7-inner",
+          "networkId": "pcb_component_7-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_8",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_543",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_544",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_8-inner",
+          "networkId": "pcb_component_8-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_9",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_545",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_546",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_9-inner",
+          "networkId": "pcb_component_9-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_10",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_547",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_548",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_10-inner",
+          "networkId": "pcb_component_10-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_11",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_549",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_550",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_11-inner",
+          "networkId": "pcb_component_11-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_12",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_551",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_552",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_12-inner",
+          "networkId": "pcb_component_12-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_13",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_553",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_554",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_13-inner",
+          "networkId": "pcb_component_13-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_14",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_555",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_556",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_14-inner",
+          "networkId": "pcb_component_14-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_15",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_557",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_558",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_15-inner",
+          "networkId": "pcb_component_15-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_16",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_559",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_560",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_16-inner",
+          "networkId": "pcb_component_16-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_17",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_561",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_562",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_17-inner",
+          "networkId": "pcb_component_17-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_18",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_563",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_564",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_18-inner",
+          "networkId": "pcb_component_18-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_19",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_565",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_566",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_19-inner",
+          "networkId": "pcb_component_19-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_20",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_567",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_568",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_20-inner",
+          "networkId": "pcb_component_20-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_21",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_569",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_570",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_21-inner",
+          "networkId": "pcb_component_21-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_22",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_571",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_572",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_22-inner",
+          "networkId": "pcb_component_22-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_23",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_573",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_574",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_23-inner",
+          "networkId": "pcb_component_23-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_24",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_575",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_576",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_24-inner",
+          "networkId": "pcb_component_24-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_25",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_577",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_578",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_25-inner",
+          "networkId": "pcb_component_25-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_26",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_579",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_580",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_26-inner",
+          "networkId": "pcb_component_26-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_27",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_581",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_582",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_27-inner",
+          "networkId": "pcb_component_27-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_28",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_583",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_584",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_28-inner",
+          "networkId": "pcb_component_28-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_29",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_585",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_586",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_29-inner",
+          "networkId": "pcb_component_29-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_30",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_587",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_588",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_30-inner",
+          "networkId": "pcb_component_30-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_31",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_589",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_590",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_31-inner",
+          "networkId": "pcb_component_31-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_32",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_591",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_592",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_32-inner",
+          "networkId": "pcb_component_32-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_33",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_593",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_594",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_33-inner",
+          "networkId": "pcb_component_33-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_34",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_595",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_596",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_34-inner",
+          "networkId": "pcb_component_34-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_35",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_597",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_598",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_35-inner",
+          "networkId": "pcb_component_35-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_36",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_599",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_600",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_36-inner",
+          "networkId": "pcb_component_36-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_37",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_601",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_602",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_37-inner",
+          "networkId": "pcb_component_37-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_38",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_603",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_604",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_38-inner",
+          "networkId": "pcb_component_38-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_39",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_605",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_606",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_39-inner",
+          "networkId": "pcb_component_39-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_40",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_607",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_608",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_40-inner",
+          "networkId": "pcb_component_40-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_41",
+      "pads": [
+        {
+          "padId": "pcb_plated_hole_0",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net83",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -2.44,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_1",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net84",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 2.44,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_41-inner",
+          "networkId": "pcb_component_41-inner",
+          "type": "rect",
+          "size": {
+            "x": 6.38,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 11.954011882049096,
+        "height": 5.659999999999999
+      }
+    },
+    {
+      "componentId": "pcb_component_42",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_609",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net83",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_610",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_42-inner",
+          "networkId": "pcb_component_42-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_43",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_611",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net84",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_612",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_43-inner",
+          "networkId": "pcb_component_43-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_44",
+      "pads": [
+        {
+          "padId": "pcb_plated_hole_2",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net85",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -2.44,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_3",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net86",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 2.44,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_44-inner",
+          "networkId": "pcb_component_44-inner",
+          "type": "rect",
+          "size": {
+            "x": 6.38,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 11.954011882049096,
+        "height": 5.659999999999999
+      }
+    },
+    {
+      "componentId": "pcb_component_45",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_613",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net85",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_614",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_45-inner",
+          "networkId": "pcb_component_45-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_46",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_615",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net86",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_616",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_46-inner",
+          "networkId": "pcb_component_46-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_47",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_617",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_618",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_619",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_620",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_621",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_622",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_623",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net12",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_624",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_625",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net14",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_626",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_627",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net16",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_628",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_629",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net18",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_630",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_631",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_632",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_633",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net22",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_634",
+          "networkId": "unnamed430",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_635",
+          "networkId": "unnamed431",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_636",
+          "networkId": "unnamed432",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_637",
+          "networkId": "unnamed433",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_638",
+          "networkId": "unnamed434",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_639",
+          "networkId": "unnamed435",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_640",
+          "networkId": "unnamed436",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_641",
+          "networkId": "unnamed437",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_642",
+          "networkId": "unnamed438",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_643",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net32",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_644",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net33",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_645",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net34",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_646",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net35",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_647",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_648",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net37",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_649",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net38",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_650",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_651",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_652",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_653",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net87",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_654",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net87",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_655",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net87",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_656",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_657",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_658",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_659",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_660",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_661",
+          "networkId": "unnamed439",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_662",
+          "networkId": "unnamed440",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_663",
+          "networkId": "unnamed441",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_664",
+          "networkId": "unnamed442",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_665",
+          "networkId": "unnamed443",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_666",
+          "networkId": "unnamed444",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_667",
+          "networkId": "unnamed445",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_668",
+          "networkId": "unnamed446",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_669",
+          "networkId": "unnamed447",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_670",
+          "networkId": "unnamed448",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_671",
+          "networkId": "unnamed449",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_672",
+          "networkId": "unnamed450",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_673",
+          "networkId": "unnamed451",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_674",
+          "networkId": "unnamed452",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_675",
+          "networkId": "unnamed453",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_676",
+          "networkId": "unnamed454",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_677",
+          "networkId": "unnamed455",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_678",
+          "networkId": "unnamed456",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_679",
+          "networkId": "unnamed457",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_680",
+          "networkId": "unnamed458",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_681",
+          "networkId": "unnamed459",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_682",
+          "networkId": "unnamed460",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_683",
+          "networkId": "unnamed461",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_684",
+          "networkId": "unnamed462",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_685",
+          "networkId": "unnamed463",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_686",
+          "networkId": "unnamed464",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_687",
+          "networkId": "unnamed465",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_688",
+          "networkId": "unnamed466",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_689",
+          "networkId": "unnamed467",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_690",
+          "networkId": "unnamed468",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_691",
+          "networkId": "unnamed469",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_692",
+          "networkId": "unnamed470",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_693",
+          "networkId": "unnamed471",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_694",
+          "networkId": "unnamed472",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_695",
+          "networkId": "unnamed473",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_696",
+          "networkId": "unnamed474",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_697",
+          "networkId": "unnamed475",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_698",
+          "networkId": "unnamed476",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_699",
+          "networkId": "unnamed477",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_700",
+          "networkId": "unnamed478",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_701",
+          "networkId": "unnamed479",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_702",
+          "networkId": "unnamed480",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_703",
+          "networkId": "unnamed481",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_704",
+          "networkId": "unnamed482",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_705",
+          "networkId": "unnamed483",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_706",
+          "networkId": "unnamed484",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_707",
+          "networkId": "unnamed485",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_708",
+          "networkId": "unnamed486",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_709",
+          "networkId": "unnamed487",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_710",
+          "networkId": "unnamed488",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_711",
+          "networkId": "unnamed489",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": -0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_712",
+          "networkId": "unnamed490",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_713",
+          "networkId": "unnamed491",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_714",
+          "networkId": "unnamed492",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_715",
+          "networkId": "unnamed493",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_716",
+          "networkId": "unnamed494",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_717",
+          "networkId": "unnamed495",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_718",
+          "networkId": "unnamed496",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_719",
+          "networkId": "unnamed497",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_720",
+          "networkId": "unnamed498",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_721",
+          "networkId": "unnamed499",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_722",
+          "networkId": "unnamed500",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_723",
+          "networkId": "unnamed501",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_724",
+          "networkId": "unnamed502",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_725",
+          "networkId": "unnamed503",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_726",
+          "networkId": "unnamed504",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_727",
+          "networkId": "unnamed505",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_728",
+          "networkId": "unnamed506",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_729",
+          "networkId": "unnamed507",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_730",
+          "networkId": "unnamed508",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_731",
+          "networkId": "unnamed509",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 0.8
+          }
+        },
+        {
+          "padId": "pcb_smtpad_732",
+          "networkId": "unnamed510",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_733",
+          "networkId": "unnamed511",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_734",
+          "networkId": "unnamed512",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_735",
+          "networkId": "unnamed513",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_736",
+          "networkId": "unnamed514",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_737",
+          "networkId": "unnamed515",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_738",
+          "networkId": "unnamed516",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_739",
+          "networkId": "unnamed517",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_740",
+          "networkId": "unnamed518",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_741",
+          "networkId": "unnamed519",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 1.6
+          }
+        },
+        {
+          "padId": "pcb_smtpad_742",
+          "networkId": "unnamed520",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_743",
+          "networkId": "unnamed521",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_744",
+          "networkId": "unnamed522",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_745",
+          "networkId": "unnamed523",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_746",
+          "networkId": "unnamed524",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_747",
+          "networkId": "unnamed525",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_748",
+          "networkId": "unnamed526",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_749",
+          "networkId": "unnamed527",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_750",
+          "networkId": "unnamed528",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_751",
+          "networkId": "unnamed529",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_752",
+          "networkId": "unnamed530",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_753",
+          "networkId": "unnamed531",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_754",
+          "networkId": "unnamed532",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_755",
+          "networkId": "unnamed533",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_756",
+          "networkId": "unnamed534",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 2.4000000000000004
+          }
+        },
+        {
+          "padId": "pcb_smtpad_757",
+          "networkId": "unnamed535",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_758",
+          "networkId": "unnamed536",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_759",
+          "networkId": "unnamed537",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_760",
+          "networkId": "unnamed538",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_761",
+          "networkId": "unnamed539",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_762",
+          "networkId": "unnamed540",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_763",
+          "networkId": "unnamed541",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_764",
+          "networkId": "unnamed542",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_765",
+          "networkId": "unnamed543",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_766",
+          "networkId": "unnamed544",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_767",
+          "networkId": "unnamed545",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_768",
+          "networkId": "unnamed546",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_769",
+          "networkId": "unnamed547",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_770",
+          "networkId": "unnamed548",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_771",
+          "networkId": "unnamed549",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 3.2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_772",
+          "networkId": "unnamed550",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_773",
+          "networkId": "unnamed551",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_774",
+          "networkId": "unnamed552",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_775",
+          "networkId": "unnamed553",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_776",
+          "networkId": "unnamed554",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_777",
+          "networkId": "unnamed555",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_778",
+          "networkId": "unnamed556",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_779",
+          "networkId": "unnamed557",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_780",
+          "networkId": "unnamed558",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_781",
+          "networkId": "unnamed559",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_782",
+          "networkId": "unnamed560",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_783",
+          "networkId": "unnamed561",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_784",
+          "networkId": "unnamed562",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_785",
+          "networkId": "unnamed563",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_786",
+          "networkId": "unnamed564",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_787",
+          "networkId": "unnamed565",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_788",
+          "networkId": "unnamed566",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_789",
+          "networkId": "unnamed567",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_790",
+          "networkId": "unnamed568",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_791",
+          "networkId": "unnamed569",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_792",
+          "networkId": "unnamed570",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_793",
+          "networkId": "unnamed571",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_794",
+          "networkId": "unnamed572",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_795",
+          "networkId": "unnamed573",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_796",
+          "networkId": "unnamed574",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_797",
+          "networkId": "unnamed575",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_798",
+          "networkId": "unnamed576",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_799",
+          "networkId": "unnamed577",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_800",
+          "networkId": "unnamed578",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_801",
+          "networkId": "unnamed579",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 4.800000000000001
+          }
+        },
+        {
+          "padId": "pcb_smtpad_802",
+          "networkId": "unnamed580",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -5.6000000000000005,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_803",
+          "networkId": "unnamed581",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4.800000000000001,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_804",
+          "networkId": "unnamed582",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -4,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_805",
+          "networkId": "unnamed583",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -3.2,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_806",
+          "networkId": "unnamed584",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -2.4000000000000004,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_807",
+          "networkId": "unnamed585",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -1.6,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_808",
+          "networkId": "unnamed586",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": -0.8,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_809",
+          "networkId": "unnamed587",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_810",
+          "networkId": "unnamed588",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 0.8,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_811",
+          "networkId": "unnamed589",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 1.6,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_812",
+          "networkId": "unnamed590",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 2.4000000000000004,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_813",
+          "networkId": "unnamed591",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 3.2,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_814",
+          "networkId": "unnamed592",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_815",
+          "networkId": "unnamed593",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 4.800000000000001,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_smtpad_816",
+          "networkId": "unnamed594",
+          "type": "rect",
+          "size": {
+            "x": 0.3779527559055118,
+            "y": 0.3779527559055118
+          },
+          "offset": {
+            "x": 5.6000000000000005,
+            "y": 5.6000000000000005
+          }
+        },
+        {
+          "padId": "pcb_component_47-inner",
+          "networkId": "pcb_component_47-inner",
+          "type": "rect",
+          "size": {
+            "x": 11.577952755905512,
+            "y": 11.577952755905512
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 15.007952755905512,
+        "height": 15.107952755905512
+      }
+    },
+    {
+      "componentId": "pcb_component_48",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_817",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_818",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net88",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_48-inner",
+          "networkId": "pcb_component_48-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_49",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_819",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net88",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_820",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_49-inner",
+          "networkId": "pcb_component_49-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_50",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_821",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net87",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_822",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_50-inner",
+          "networkId": "pcb_component_50-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_51",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_823",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_824",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_51-inner",
+          "networkId": "pcb_component_51-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_52",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_825",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_826",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_52-inner",
+          "networkId": "pcb_component_52-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_53",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_827",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_828",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_53-inner",
+          "networkId": "pcb_component_53-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_54",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_829",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net87",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_830",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_54-inner",
+          "networkId": "pcb_component_54-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_55",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_831",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net87",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_832",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_55-inner",
+          "networkId": "pcb_component_55-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_56",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_833",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net87",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_834",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_56-inner",
+          "networkId": "pcb_component_56-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_57",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_835",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_836",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": 3.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_837",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": 3
+          }
+        },
+        {
+          "padId": "pcb_smtpad_838",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": 2.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_839",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": 2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_840",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": 1.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_841",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net90",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": 1
+          }
+        },
+        {
+          "padId": "pcb_smtpad_842",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net90",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": 0.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_843",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net91",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_844",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net91",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": -0.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_845",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net92",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": -1
+          }
+        },
+        {
+          "padId": "pcb_smtpad_846",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net92",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": -1.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_847",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net93",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": -2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_848",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net93",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": -2.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_849",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net94",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": -3
+          }
+        },
+        {
+          "padId": "pcb_smtpad_850",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net94",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": -3.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_851",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -4.7125,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_852",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -4,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_853",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -3.5,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_854",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -3,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_855",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -2.5,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_856",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -2,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_857",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.5,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_858",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_859",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.5,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_860",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_861",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.5,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_862",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_863",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.5,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_864",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 2,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_865",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 2.5,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_866",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 3,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_867",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 3.5,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_868",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 4,
+            "y": -4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_869",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": -4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_870",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": -3.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_871",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net95",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": -3
+          }
+        },
+        {
+          "padId": "pcb_smtpad_872",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net96",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": -2.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_873",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net67",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": -2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_874",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": -1.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_875",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": -1
+          }
+        },
+        {
+          "padId": "pcb_smtpad_876",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": -0.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_877",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_878",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": 0.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_879",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": 1
+          }
+        },
+        {
+          "padId": "pcb_smtpad_880",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": 1.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_881",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": 2
+          }
+        },
+        {
+          "padId": "pcb_smtpad_882",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": 2.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_883",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": 3
+          }
+        },
+        {
+          "padId": "pcb_smtpad_884",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": 3.5
+          }
+        },
+        {
+          "padId": "pcb_smtpad_885",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 4.7125,
+            "y": 4
+          }
+        },
+        {
+          "padId": "pcb_smtpad_886",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 4,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_887",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 3.5,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_888",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 3,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_889",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 2.5,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_890",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 2,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_891",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.5,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_892",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_893",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.5,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_894",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_895",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.5,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_896",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_897",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.5,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_898",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -2,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_899",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -2.5,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_900",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -3,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_901",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -3.5,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_smtpad_902",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -4,
+            "y": 4.7125
+          }
+        },
+        {
+          "padId": "pcb_component_57-inner",
+          "networkId": "pcb_component_57-inner",
+          "type": "rect",
+          "size": {
+            "x": 10.3,
+            "y": 10.3
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 11,
+        "height": 11
+      }
+    },
+    {
+      "componentId": "pcb_component_58",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_903",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_904",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_58-inner",
+          "networkId": "pcb_component_58-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_59",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_905",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_906",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_59-inner",
+          "networkId": "pcb_component_59-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_60",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_907",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net90",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_908",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_60-inner",
+          "networkId": "pcb_component_60-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_61",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_909",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_910",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_61-inner",
+          "networkId": "pcb_component_61-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_62",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_911",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_912",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_62-inner",
+          "networkId": "pcb_component_62-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_63",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_913",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net91",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_914",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_63-inner",
+          "networkId": "pcb_component_63-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_64",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_915",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_916",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_64-inner",
+          "networkId": "pcb_component_64-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_65",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_917",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_918",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_65-inner",
+          "networkId": "pcb_component_65-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_66",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_919",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net92",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_920",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_66-inner",
+          "networkId": "pcb_component_66-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_67",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_921",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_922",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_67-inner",
+          "networkId": "pcb_component_67-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_68",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_923",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_924",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_68-inner",
+          "networkId": "pcb_component_68-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_69",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_925",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net93",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_926",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_69-inner",
+          "networkId": "pcb_component_69-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_70",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_927",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_928",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_70-inner",
+          "networkId": "pcb_component_70-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_71",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_929",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_930",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_71-inner",
+          "networkId": "pcb_component_71-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_72",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_931",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net94",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_932",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_72-inner",
+          "networkId": "pcb_component_72-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_73",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_933",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_934",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_73-inner",
+          "networkId": "pcb_component_73-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_74",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_935",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_936",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_74-inner",
+          "networkId": "pcb_component_74-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_75",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_937",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_938",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_75-inner",
+          "networkId": "pcb_component_75-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_76",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_939",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_940",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_76-inner",
+          "networkId": "pcb_component_76-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_77",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_941",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_942",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net95",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_77-inner",
+          "networkId": "pcb_component_77-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_78",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_943",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_944",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net96",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_78-inner",
+          "networkId": "pcb_component_78-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_79",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_945",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net67",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_946",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_79-inner",
+          "networkId": "pcb_component_79-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_80",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_947",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": 1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_948",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net97",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": 1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_949",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net98",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": 0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_950",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net74",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": 0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_951",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net75",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": -0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_952",
+          "networkId": "unnamed595",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": -0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_953",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net97",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": -1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_954",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": -1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_955",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.75,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_956",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net97",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.25,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_957",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net99",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.75,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_958",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net74",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.25,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_959",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net75",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.25,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_960",
+          "networkId": "unnamed596",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.75,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_961",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net97",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.25,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_962",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.75,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_963",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": -1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_964",
+          "networkId": "unnamed597",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": -1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_965",
+          "networkId": "unnamed598",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": -0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_966",
+          "networkId": "unnamed599",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": -0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_967",
+          "networkId": "unnamed600",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": 0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_968",
+          "networkId": "unnamed601",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": 0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_969",
+          "networkId": "unnamed602",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": 1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_970",
+          "networkId": "unnamed603",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": 1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_971",
+          "networkId": "unnamed604",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.75,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_972",
+          "networkId": "unnamed605",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.25,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_973",
+          "networkId": "unnamed606",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.75,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_974",
+          "networkId": "unnamed607",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.25,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_975",
+          "networkId": "unnamed608",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.25,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_976",
+          "networkId": "unnamed609",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.75,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_977",
+          "networkId": "unnamed610",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.25,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_978",
+          "networkId": "unnamed611",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.75,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_component_80-inner",
+          "networkId": "pcb_component_80-inner",
+          "type": "rect",
+          "size": {
+            "x": 5.8,
+            "y": 5.8
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 6.5,
+        "height": 6.5
+      }
+    },
+    {
+      "componentId": "pcb_component_81",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_979",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net98",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_980",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_81-inner",
+          "networkId": "pcb_component_81-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_82",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_981",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net99",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_982",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_82-inner",
+          "networkId": "pcb_component_82-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_83",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_983",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net98",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": 1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_984",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net99",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": 1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_985",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net97",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": 0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_986",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": 0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_987",
+          "networkId": "unnamed612",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": -0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_988",
+          "networkId": "unnamed613",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": -0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_989",
+          "networkId": "unnamed614",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": -1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_990",
+          "networkId": "unnamed615",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": -1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_991",
+          "networkId": "unnamed616",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.75,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_992",
+          "networkId": "unnamed617",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.25,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_993",
+          "networkId": "unnamed618",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.75,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_994",
+          "networkId": "unnamed619",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.25,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_995",
+          "networkId": "unnamed620",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.25,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_996",
+          "networkId": "unnamed621",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.75,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_997",
+          "networkId": "unnamed622",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.25,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_998",
+          "networkId": "unnamed623",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.75,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_999",
+          "networkId": "unnamed624",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": -1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1000",
+          "networkId": "unnamed625",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": -1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1001",
+          "networkId": "unnamed626",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": -0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1002",
+          "networkId": "unnamed627",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": -0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1003",
+          "networkId": "unnamed628",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": 0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1004",
+          "networkId": "unnamed629",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": 0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1005",
+          "networkId": "unnamed630",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": 1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1006",
+          "networkId": "unnamed631",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": 1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1007",
+          "networkId": "unnamed632",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.75,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1008",
+          "networkId": "unnamed633",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.25,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1009",
+          "networkId": "unnamed634",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.75,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1010",
+          "networkId": "unnamed635",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.25,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1011",
+          "networkId": "unnamed636",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.25,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1012",
+          "networkId": "unnamed637",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.75,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1013",
+          "networkId": "unnamed638",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.25,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1014",
+          "networkId": "unnamed639",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.75,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_component_83-inner",
+          "networkId": "pcb_component_83-inner",
+          "type": "rect",
+          "size": {
+            "x": 5.8,
+            "y": 5.8
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 6.5,
+        "height": 6.5
+      }
+    },
+    {
+      "componentId": "pcb_component_84",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1015",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net74",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1016",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net75",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1017",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net98",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1018",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net99",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.1375,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1019",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.1375,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_component_84-inner",
+          "networkId": "pcb_component_84-inner",
+          "type": "rect",
+          "size": {
+            "x": 3.5999999999999996,
+            "y": 2.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 4.1,
+        "height": 3.4
+      }
+    },
+    {
+      "componentId": "pcb_component_85",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1020",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.9,
+            "y": 1.2
+          },
+          "offset": {
+            "x": -1.65,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1021",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net97",
+          "type": "rect",
+          "size": {
+            "x": 0.9,
+            "y": 1.2
+          },
+          "offset": {
+            "x": 1.65,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_85-inner",
+          "networkId": "pcb_component_85-inner",
+          "type": "rect",
+          "size": {
+            "x": 4.2,
+            "y": 1.2
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 4.7,
+        "height": 2.3
+      }
+    },
+    {
+      "componentId": "pcb_component_86",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1022",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net100",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1023",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net97",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1024",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.1375,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_86-inner",
+          "networkId": "pcb_component_86-inner",
+          "type": "rect",
+          "size": {
+            "x": 3.5999999999999996,
+            "y": 2.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 4.1,
+        "height": 3.4
+      }
+    },
+    {
+      "componentId": "pcb_component_87",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1025",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net100",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1026",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_87-inner",
+          "networkId": "pcb_component_87-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_88",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1027",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net97",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1028",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net100",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_88-inner",
+          "networkId": "pcb_component_88-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_89",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1029",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net101",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -1.4625,
+            "y": 0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1030",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net101",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -1.4625,
+            "y": 0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1031",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -1.4625,
+            "y": -0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1032",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -1.4625,
+            "y": -0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1033",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.75,
+            "y": -1.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1034",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net102",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.25,
+            "y": -1.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1035",
+          "networkId": "unnamed640",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.25,
+            "y": -1.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1036",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.75,
+            "y": -1.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1037",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net103",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 1.4625,
+            "y": -0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1038",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 1.4625,
+            "y": -0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1039",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 1.4625,
+            "y": 0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1040",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 1.4625,
+            "y": 0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1041",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.75,
+            "y": 1.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1042",
+          "networkId": "unnamed641",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.25,
+            "y": 1.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1043",
+          "networkId": "unnamed642",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.25,
+            "y": 1.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1044",
+          "networkId": "unnamed643",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.75,
+            "y": 1.4625
+          }
+        },
+        {
+          "padId": "pcb_component_89-inner",
+          "networkId": "pcb_component_89-inner",
+          "type": "rect",
+          "size": {
+            "x": 3.8,
+            "y": 3.8
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 4.5,
+        "height": 4.5
+      }
+    },
+    {
+      "componentId": "pcb_component_90",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1045",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1046",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_90-inner",
+          "networkId": "pcb_component_90-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_91",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1047",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1048",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_91-inner",
+          "networkId": "pcb_component_91-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_92",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1049",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1050",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_92-inner",
+          "networkId": "pcb_component_92-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_93",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1051",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1052",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_93-inner",
+          "networkId": "pcb_component_93-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_94",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1053",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net101",
+          "type": "rect",
+          "size": {
+            "x": 1.125,
+            "y": 2.65
+          },
+          "offset": {
+            "x": -1.4625,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1054",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.125,
+            "y": 2.65
+          },
+          "offset": {
+            "x": 1.4625,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_94-inner",
+          "networkId": "pcb_component_94-inner",
+          "type": "rect",
+          "size": {
+            "x": 4.05,
+            "y": 2.65
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 4.56,
+        "height": 3.16
+      }
+    },
+    {
+      "componentId": "pcb_component_95",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1055",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1056",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_95-inner",
+          "networkId": "pcb_component_95-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_96",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1057",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1058",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_96-inner",
+          "networkId": "pcb_component_96-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_97",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1059",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1060",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net102",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_97-inner",
+          "networkId": "pcb_component_97-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_98",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1061",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net102",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1062",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_98-inner",
+          "networkId": "pcb_component_98-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_99",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1063",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1064",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net102",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_99-inner",
+          "networkId": "pcb_component_99-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_100",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1065",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net103",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1066",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_100-inner",
+          "networkId": "pcb_component_100-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_101",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1067",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net104",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -1.4625,
+            "y": 0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1068",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net104",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -1.4625,
+            "y": 0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1069",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -1.4625,
+            "y": -0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1070",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -1.4625,
+            "y": -0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1071",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.75,
+            "y": -1.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1072",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.25,
+            "y": -1.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1073",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.25,
+            "y": -1.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1074",
+          "networkId": "unnamed644",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.75,
+            "y": -1.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1075",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 1.4625,
+            "y": -0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1076",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net105",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 1.4625,
+            "y": -0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1077",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net106",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 1.4625,
+            "y": 0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1078",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 1.4625,
+            "y": 0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1079",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.75,
+            "y": 1.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1080",
+          "networkId": "unnamed645",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.25,
+            "y": 1.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1081",
+          "networkId": "unnamed646",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.25,
+            "y": 1.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1082",
+          "networkId": "unnamed647",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.75,
+            "y": 1.4625
+          }
+        },
+        {
+          "padId": "pcb_component_101-inner",
+          "networkId": "pcb_component_101-inner",
+          "type": "rect",
+          "size": {
+            "x": 3.8,
+            "y": 3.8
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 4.5,
+        "height": 4.5
+      }
+    },
+    {
+      "componentId": "pcb_component_102",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1083",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1084",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_102-inner",
+          "networkId": "pcb_component_102-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_103",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1085",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1086",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_103-inner",
+          "networkId": "pcb_component_103-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_104",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1087",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1088",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_104-inner",
+          "networkId": "pcb_component_104-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_105",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1089",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net104",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1090",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_105-inner",
+          "networkId": "pcb_component_105-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_106",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1091",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1092",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_106-inner",
+          "networkId": "pcb_component_106-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_107",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1093",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1094",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_107-inner",
+          "networkId": "pcb_component_107-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_108",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1095",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1096",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_108-inner",
+          "networkId": "pcb_component_108-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_109",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1097",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1098",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net105",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_109-inner",
+          "networkId": "pcb_component_109-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_110",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1099",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net105",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1100",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_110-inner",
+          "networkId": "pcb_component_110-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_111",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1101",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net106",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1102",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_111-inner",
+          "networkId": "pcb_component_111-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_112",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1103",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1104",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1105",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1106",
+          "networkId": "unnamed648",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.1375,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1107",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net87",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.1375,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_component_112-inner",
+          "networkId": "pcb_component_112-inner",
+          "type": "rect",
+          "size": {
+            "x": 3.5999999999999996,
+            "y": 2.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 4.1,
+        "height": 3.4
+      }
+    },
+    {
+      "componentId": "pcb_component_113",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1108",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1109",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_113-inner",
+          "networkId": "pcb_component_113-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_114",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1110",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net87",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1111",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_114-inner",
+          "networkId": "pcb_component_114-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_115",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1112",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1113",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1114",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1115",
+          "networkId": "unnamed649",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.1375,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1116",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net107",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.1375,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_component_115-inner",
+          "networkId": "pcb_component_115-inner",
+          "type": "rect",
+          "size": {
+            "x": 3.5999999999999996,
+            "y": 2.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 4.1,
+        "height": 3.4
+      }
+    },
+    {
+      "componentId": "pcb_component_116",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1117",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1118",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_116-inner",
+          "networkId": "pcb_component_116-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_117",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1119",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net107",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1120",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_117-inner",
+          "networkId": "pcb_component_117-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_118",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1121",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1122",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net108",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1123",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1124",
+          "networkId": "unnamed650",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.1375,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1125",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.1375,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_component_118-inner",
+          "networkId": "pcb_component_118-inner",
+          "type": "rect",
+          "size": {
+            "x": 3.5999999999999996,
+            "y": 2.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 4.1,
+        "height": 3.4
+      }
+    },
+    {
+      "componentId": "pcb_component_119",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1126",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1127",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_119-inner",
+          "networkId": "pcb_component_119-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_120",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1128",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net108",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1129",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_120-inner",
+          "networkId": "pcb_component_120-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_121",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1130",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1131",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1132",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1133",
+          "networkId": "unnamed651",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.1375,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1134",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net109",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.1375,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_component_121-inner",
+          "networkId": "pcb_component_121-inner",
+          "type": "rect",
+          "size": {
+            "x": 3.5999999999999996,
+            "y": 2.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 4.1,
+        "height": 3.4
+      }
+    },
+    {
+      "componentId": "pcb_component_122",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1135",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1136",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_122-inner",
+          "networkId": "pcb_component_122-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_123",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1137",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net109",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1138",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_123-inner",
+          "networkId": "pcb_component_123-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_124",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1139",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1140",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_124-inner",
+          "networkId": "pcb_component_124-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_125",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1141",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1142",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_125-inner",
+          "networkId": "pcb_component_125-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_126",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1143",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1144",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_126-inner",
+          "networkId": "pcb_component_126-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_127",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1145",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1146",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_127-inner",
+          "networkId": "pcb_component_127-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_128",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1147",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1148",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_128-inner",
+          "networkId": "pcb_component_128-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_129",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1149",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1150",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_129-inner",
+          "networkId": "pcb_component_129-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_130",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1151",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1152",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_130-inner",
+          "networkId": "pcb_component_130-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_131",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1153",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1154",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_131-inner",
+          "networkId": "pcb_component_131-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_132",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1155",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1156",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_132-inner",
+          "networkId": "pcb_component_132-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_133",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1157",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1158",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_133-inner",
+          "networkId": "pcb_component_133-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_134",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1159",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1160",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_134-inner",
+          "networkId": "pcb_component_134-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_135",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1161",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1162",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_135-inner",
+          "networkId": "pcb_component_135-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_136",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1163",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -3.4625,
+            "y": 2.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1164",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -3.4625,
+            "y": 2.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1165",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -3.4625,
+            "y": 1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1166",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -3.4625,
+            "y": 1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1167",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net50",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -3.4625,
+            "y": 0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1168",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net51",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -3.4625,
+            "y": 0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1169",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net54",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -3.4625,
+            "y": -0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1170",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net55",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -3.4625,
+            "y": -0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1171",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net56",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -3.4625,
+            "y": -1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1172",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net57",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -3.4625,
+            "y": -1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1173",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net52",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -3.4625,
+            "y": -2.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1174",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net53",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -3.4625,
+            "y": -2.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1175",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net58",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -2.75,
+            "y": -3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1176",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net59",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -2.25,
+            "y": -3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1177",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net60",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.75,
+            "y": -3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1178",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net61",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.25,
+            "y": -3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1179",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net110",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.75,
+            "y": -3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1180",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net111",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.25,
+            "y": -3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1181",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net112",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.25,
+            "y": -3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1182",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net113",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.75,
+            "y": -3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1183",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net114",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.25,
+            "y": -3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1184",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net115",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.75,
+            "y": -3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1185",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net116",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 2.25,
+            "y": -3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1186",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net117",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 2.75,
+            "y": -3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1187",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net118",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 3.4625,
+            "y": -2.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1188",
+          "networkId": "unnamed652",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 3.4625,
+            "y": -2.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1189",
+          "networkId": "unnamed653",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 3.4625,
+            "y": -1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1190",
+          "networkId": "unnamed654",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 3.4625,
+            "y": -1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1191",
+          "networkId": "unnamed655",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 3.4625,
+            "y": -0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1192",
+          "networkId": "unnamed656",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 3.4625,
+            "y": -0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1193",
+          "networkId": "unnamed657",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 3.4625,
+            "y": 0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1194",
+          "networkId": "unnamed658",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 3.4625,
+            "y": 0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1195",
+          "networkId": "unnamed659",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 3.4625,
+            "y": 1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1196",
+          "networkId": "unnamed660",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 3.4625,
+            "y": 1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1197",
+          "networkId": "unnamed661",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 3.4625,
+            "y": 2.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1198",
+          "networkId": "unnamed662",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 3.4625,
+            "y": 2.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1199",
+          "networkId": "unnamed663",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 2.75,
+            "y": 3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1200",
+          "networkId": "unnamed664",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 2.25,
+            "y": 3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1201",
+          "networkId": "unnamed665",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.75,
+            "y": 3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1202",
+          "networkId": "unnamed666",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.25,
+            "y": 3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1203",
+          "networkId": "unnamed667",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.75,
+            "y": 3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1204",
+          "networkId": "unnamed668",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.25,
+            "y": 3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1205",
+          "networkId": "unnamed669",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.25,
+            "y": 3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1206",
+          "networkId": "unnamed670",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.75,
+            "y": 3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1207",
+          "networkId": "unnamed671",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.25,
+            "y": 3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1208",
+          "networkId": "unnamed672",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.75,
+            "y": 3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1209",
+          "networkId": "unnamed673",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -2.25,
+            "y": 3.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1210",
+          "networkId": "unnamed674",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -2.75,
+            "y": 3.4625
+          }
+        },
+        {
+          "padId": "pcb_component_136-inner",
+          "networkId": "pcb_component_136-inner",
+          "type": "rect",
+          "size": {
+            "x": 7.8,
+            "y": 7.8
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 8.5,
+        "height": 8.5
+      }
+    },
+    {
+      "componentId": "pcb_component_137",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1211",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net111",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1212",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_137-inner",
+          "networkId": "pcb_component_137-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_138",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1213",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net112",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1214",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_138-inner",
+          "networkId": "pcb_component_138-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_139",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1215",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net58",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1216",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_139-inner",
+          "networkId": "pcb_component_139-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_140",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1217",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net59",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1218",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_140-inner",
+          "networkId": "pcb_component_140-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_141",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1219",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net60",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1220",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_141-inner",
+          "networkId": "pcb_component_141-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_142",
+      "pads": [
+        {
+          "padId": "pcb_plated_hole_4",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net117",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -2.44,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_5",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net118",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 2.44,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_142-inner",
+          "networkId": "pcb_component_142-inner",
+          "type": "rect",
+          "size": {
+            "x": 6.38,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 11.954011882049096,
+        "height": 5.659999999999999
+      }
+    },
+    {
+      "componentId": "pcb_component_143",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1221",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net117",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1222",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_143-inner",
+          "networkId": "pcb_component_143-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_144",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1223",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net118",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1224",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_144-inner",
+          "networkId": "pcb_component_144-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_145",
+      "pads": [
+        {
+          "padId": "pcb_plated_hole_6",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net113",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -19.05,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_7",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net114",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -16.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_8",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net115",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -13.97,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_9",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net116",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -11.43,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_10",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -8.89,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_11",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -6.350000000000001,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_12",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net119",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -3.8100000000000005,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_13",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net120",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -1.2699999999999996,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_14",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net121",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 1.2699999999999996,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_15",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net122",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 3.8099999999999987,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_16",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net123",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 6.349999999999998,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_17",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net124",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 8.89,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_18",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net125",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 11.43,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_19",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net126",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 13.970000000000002,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_20",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 16.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_21",
+          "networkId": "unnamed675",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 19.05,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_145-inner",
+          "networkId": "pcb_component_145-inner",
+          "type": "rect",
+          "size": {
+            "x": 39.6,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 41.64,
+        "height": 3.54
+      }
+    },
+    {
+      "componentId": "pcb_component_146",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1225",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net123",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1226",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net127",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_146-inner",
+          "networkId": "pcb_component_146-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_147",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1227",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net124",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1228",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net127",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_147-inner",
+          "networkId": "pcb_component_147-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_148",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1229",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net125",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1230",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net127",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_148-inner",
+          "networkId": "pcb_component_148-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_149",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1231",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net126",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1232",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net127",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_149-inner",
+          "networkId": "pcb_component_149-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_150",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1233",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net127",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1234",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_150-inner",
+          "networkId": "pcb_component_150-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_151",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1235",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1236",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net119",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_151-inner",
+          "networkId": "pcb_component_151-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_152",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1237",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1238",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net121",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_152-inner",
+          "networkId": "pcb_component_152-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_153",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1239",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net128",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1240",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net129",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_153-inner",
+          "networkId": "pcb_component_153-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_154",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1241",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net130",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1242",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net131",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_154-inner",
+          "networkId": "pcb_component_154-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_155",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1243",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net132",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1244",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net133",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_155-inner",
+          "networkId": "pcb_component_155-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_156",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1245",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net134",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1246",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net135",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_156-inner",
+          "networkId": "pcb_component_156-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_157",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1247",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net76",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1248",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net136",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_157-inner",
+          "networkId": "pcb_component_157-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_158",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1249",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net77",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1250",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net137",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_158-inner",
+          "networkId": "pcb_component_158-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_159",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1251",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net138",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1252",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net139",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_159-inner",
+          "networkId": "pcb_component_159-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_160",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1253",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net140",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1254",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net141",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_160-inner",
+          "networkId": "pcb_component_160-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_161",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1255",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net129",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1256",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_161-inner",
+          "networkId": "pcb_component_161-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_162",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1257",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net131",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1258",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_162-inner",
+          "networkId": "pcb_component_162-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_163",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1259",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net133",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1260",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_163-inner",
+          "networkId": "pcb_component_163-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_164",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1261",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net135",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1262",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_164-inner",
+          "networkId": "pcb_component_164-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_165",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1263",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net136",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1264",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_165-inner",
+          "networkId": "pcb_component_165-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_166",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1265",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net137",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1266",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_166-inner",
+          "networkId": "pcb_component_166-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_167",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1267",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net139",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1268",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_167-inner",
+          "networkId": "pcb_component_167-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_168",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1269",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net141",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1270",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_168-inner",
+          "networkId": "pcb_component_168-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_169",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1271",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1272",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_169-inner",
+          "networkId": "pcb_component_169-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_170",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1273",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1274",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_170-inner",
+          "networkId": "pcb_component_170-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_171",
+      "pads": [
+        {
+          "padId": "pcb_plated_hole_22",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net129",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -24.13,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_23",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -21.59,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_24",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net131",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -19.049999999999997,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_25",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net133",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -16.509999999999998,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_26",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -13.969999999999999,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_27",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net135",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -11.43,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_28",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net136",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -8.889999999999999,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_29",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -6.349999999999998,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_30",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net137",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -3.8099999999999987,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_31",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net139",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -1.2699999999999996,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_32",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 1.2699999999999996,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_33",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net141",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 3.8100000000000023,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_34",
+          "networkId": "unnamed676",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 6.350000000000001,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_35",
+          "networkId": "unnamed677",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 8.890000000000004,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_36",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 11.430000000000003,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_37",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 13.970000000000002,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_38",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 16.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_39",
+          "networkId": "unnamed678",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 19.05,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_40",
+          "networkId": "unnamed679",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 21.59,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_41",
+          "networkId": "unnamed680",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 24.13,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_171-inner",
+          "networkId": "pcb_component_171-inner",
+          "type": "rect",
+          "size": {
+            "x": 49.76,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 51.8,
+        "height": 3.54
+      }
+    },
+    {
+      "componentId": "pcb_component_172",
+      "pads": [
+        {
+          "padId": "pcb_plated_hole_42",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net128",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -24.13,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_43",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -21.59,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_44",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net130",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -19.049999999999997,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_45",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net132",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -16.509999999999998,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_46",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -13.969999999999999,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_47",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net134",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -11.43,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_48",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net76",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -8.889999999999999,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_49",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -6.349999999999998,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_50",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net77",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -3.8099999999999987,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_51",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net138",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -1.2699999999999996,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_52",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 1.2699999999999996,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_53",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net140",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 3.8100000000000023,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_54",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net142",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 6.350000000000001,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_55",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net143",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 8.890000000000004,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_56",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net144",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 11.430000000000003,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_57",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net145",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 13.970000000000002,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_58",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 16.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_59",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 19.05,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_60",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net146",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 21.59,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_61",
+          "networkId": "unnamed681",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 24.13,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_172-inner",
+          "networkId": "pcb_component_172-inner",
+          "type": "rect",
+          "size": {
+            "x": 49.76,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 51.8,
+        "height": 3.54
+      }
+    },
+    {
+      "componentId": "pcb_component_173",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1275",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net128",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1276",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_173-inner",
+          "networkId": "pcb_component_173-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_174",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1277",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net130",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1278",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_174-inner",
+          "networkId": "pcb_component_174-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_175",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1279",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net132",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1280",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_175-inner",
+          "networkId": "pcb_component_175-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_176",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1281",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net134",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1282",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_176-inner",
+          "networkId": "pcb_component_176-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_177",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1283",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net76",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1284",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_177-inner",
+          "networkId": "pcb_component_177-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_178",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1285",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net77",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1286",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_178-inner",
+          "networkId": "pcb_component_178-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_179",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1287",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net138",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1288",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_179-inner",
+          "networkId": "pcb_component_179-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_180",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1289",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net140",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1290",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_180-inner",
+          "networkId": "pcb_component_180-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_181",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1291",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net108",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": 1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1292",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net108",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": 1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1293",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": 0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1294",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net78",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": 0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1295",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net79",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": -0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1296",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net80",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": -0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1297",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net81",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": -1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1298",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net82",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": -2.4625,
+            "y": -1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1299",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.75,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1300",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.25,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1301",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net147",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.75,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1302",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net148",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.25,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1303",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net149",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.25,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1304",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net150",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.75,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1305",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net151",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.25,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1306",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.75,
+            "y": -2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1307",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": -1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1308",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": -1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1309",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": -0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1310",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": -0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1311",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net152",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": 0.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1312",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net153",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": 0.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1313",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net108",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": 1.25
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1314",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.875,
+            "y": 0.25
+          },
+          "offset": {
+            "x": 2.4625,
+            "y": 1.75
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1315",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.75,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1316",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 1.25,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1317",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.75,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1318",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": 0.25,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1319",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.25,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1320",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -0.75,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1321",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.25,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1322",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.25,
+            "y": 0.875
+          },
+          "offset": {
+            "x": -1.75,
+            "y": 2.4625
+          }
+        },
+        {
+          "padId": "pcb_component_181-inner",
+          "networkId": "pcb_component_181-inner",
+          "type": "rect",
+          "size": {
+            "x": 5.8,
+            "y": 5.8
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 6.5,
+        "height": 6.5
+      }
+    },
+    {
+      "componentId": "pcb_component_182",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1323",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net108",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1324",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_182-inner",
+          "networkId": "pcb_component_182-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_183",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1325",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net108",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1326",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_183-inner",
+          "networkId": "pcb_component_183-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_184",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1327",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net108",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1328",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net147",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_184-inner",
+          "networkId": "pcb_component_184-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_185",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1329",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net108",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1330",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_185-inner",
+          "networkId": "pcb_component_185-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_186",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1331",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net108",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1332",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_186-inner",
+          "networkId": "pcb_component_186-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_187",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1333",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net108",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1334",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_187-inner",
+          "networkId": "pcb_component_187-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_188",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1335",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net151",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1336",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_188-inner",
+          "networkId": "pcb_component_188-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_189",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1337",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net150",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1338",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_189-inner",
+          "networkId": "pcb_component_189-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_190",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1339",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net152",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1340",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net153",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_190-inner",
+          "networkId": "pcb_component_190-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_191",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1341",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net148",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1342",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net154",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_191-inner",
+          "networkId": "pcb_component_191-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_192",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1343",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net149",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1344",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net155",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_192-inner",
+          "networkId": "pcb_component_192-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_193",
+      "pads": [
+        {
+          "padId": "pcb_plated_hole_62",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net154",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -2.54,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_63",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net155",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_64",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 2.54,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_193-inner",
+          "networkId": "pcb_component_193-inner",
+          "type": "rect",
+          "size": {
+            "x": 6.58,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 8.620000000000001,
+        "height": 3.54
+      }
+    },
+    {
+      "componentId": "pcb_component_194",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1345",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net156",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1346",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1347",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net157",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1348",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.1375,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1349",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net158",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.1375,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_component_194-inner",
+          "networkId": "pcb_component_194-inner",
+          "type": "rect",
+          "size": {
+            "x": 3.5999999999999996,
+            "y": 2.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 4.1,
+        "height": 3.4
+      }
+    },
+    {
+      "componentId": "pcb_component_195",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1350",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net156",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1351",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_195-inner",
+          "networkId": "pcb_component_195-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_196",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1352",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net74",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.3,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1353",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.3,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1354",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net75",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.3,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1355",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net75",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.3,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1356",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net158",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.3,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1357",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net74",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.3,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_component_196-inner",
+          "networkId": "pcb_component_196-inner",
+          "type": "rect",
+          "size": {
+            "x": 3.6,
+            "y": 2.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 4.1,
+        "height": 3.475
+      }
+    },
+    {
+      "componentId": "pcb_component_197",
+      "pads": [
+        {
+          "padId": "pcb_plated_hole_65",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net158",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -6.35,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_66",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net75",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -3.8099999999999996,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_67",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net74",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -1.2699999999999996,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_68",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 1.2700000000000005,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_69",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 3.8100000000000005,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_70",
+          "networkId": "unnamed682",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 6.35,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_197-inner",
+          "networkId": "pcb_component_197-inner",
+          "type": "rect",
+          "size": {
+            "x": 14.2,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 16.24,
+        "height": 3.54
+      }
+    },
+    {
+      "componentId": "pcb_component_198",
+      "pads": [
+        {
+          "padId": "pcb_plated_hole_71",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net159",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -10.16,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_72",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net160",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -7.62,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_73",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net161",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -5.08,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_74",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -2.54,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_75",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net162",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_76",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 2.539999999999999,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_77",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net163",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 5.08,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_78",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net164",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 7.620000000000001,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_79",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net165",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 10.16,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_198-inner",
+          "networkId": "pcb_component_198-inner",
+          "type": "rect",
+          "size": {
+            "x": 21.82,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 23.86,
+        "height": 3.54
+      }
+    },
+    {
+      "componentId": "pcb_component_199",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1358",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -2.15,
+            "y": 4.445
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1359",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -2.15,
+            "y": 3.1750000000000003
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1360",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -2.15,
+            "y": 1.9050000000000002
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1361",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -2.15,
+            "y": 0.6350000000000002
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1362",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net166",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -2.15,
+            "y": -0.6349999999999998
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1363",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net167",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -2.15,
+            "y": -1.9049999999999994
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1364",
+          "networkId": "unnamed683",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -2.15,
+            "y": -3.175
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1365",
+          "networkId": "unnamed684",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -2.15,
+            "y": -4.445
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1366",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 2.15,
+            "y": -4.445
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1367",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 2.15,
+            "y": -3.1750000000000003
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1368",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 2.15,
+            "y": -1.9050000000000002
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1369",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 2.15,
+            "y": -0.6350000000000002
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1370",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 2.15,
+            "y": 0.6349999999999998
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1371",
+          "networkId": "unnamed685",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 2.15,
+            "y": 1.9049999999999994
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1372",
+          "networkId": "unnamed686",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 2.15,
+            "y": 3.175
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1373",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 2.15,
+            "y": 4.445
+          }
+        },
+        {
+          "padId": "pcb_component_199-inner",
+          "networkId": "pcb_component_199-inner",
+          "type": "rect",
+          "size": {
+            "x": 5.3,
+            "y": 9.49
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 5.8,
+        "height": 10.625
+      }
+    },
+    {
+      "componentId": "pcb_component_200",
+      "pads": [
+        {
+          "padId": "pcb_plated_hole_80",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -11.43,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_81",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net71",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -8.89,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_82",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -6.35,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_83",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net70",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -3.8099999999999996,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_84",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -1.2699999999999996,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_85",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net73",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 1.2699999999999996,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_86",
+          "networkId": "unnamed687",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 3.8100000000000005,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_87",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net72",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 6.350000000000001,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_88",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 8.89,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_89",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net66",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 11.43,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_200-inner",
+          "networkId": "pcb_component_200-inner",
+          "type": "rect",
+          "size": {
+            "x": 24.36,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 26.4,
+        "height": 3.54
+      }
+    },
+    {
+      "componentId": "pcb_component_201",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1374",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net68",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1375",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_201-inner",
+          "networkId": "pcb_component_201-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_202",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1376",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net69",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1377",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_202-inner",
+          "networkId": "pcb_component_202-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_203",
+      "pads": [
+        {
+          "padId": "pcb_plated_hole_90",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -6.35,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_91",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net68",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -3.8099999999999996,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_92",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -1.2699999999999996,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_93",
+          "networkId": "unnamed688",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 1.2700000000000005,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_94",
+          "networkId": "unnamed689",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 3.8100000000000005,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_95",
+          "networkId": "unnamed690",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 6.35,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_203-inner",
+          "networkId": "pcb_component_203-inner",
+          "type": "rect",
+          "size": {
+            "x": 14.2,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 16.24,
+        "height": 3.54
+      }
+    },
+    {
+      "componentId": "pcb_component_204",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1378",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net67",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1379",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1380",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net66",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -1.1375,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1381",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.1375,
+            "y": -0.95
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1382",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net168",
+          "type": "rect",
+          "size": {
+            "x": 1.325,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 1.1375,
+            "y": 0.95
+          }
+        },
+        {
+          "padId": "pcb_component_204-inner",
+          "networkId": "pcb_component_204-inner",
+          "type": "rect",
+          "size": {
+            "x": 3.5999999999999996,
+            "y": 2.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 4.1,
+        "height": 3.4
+      }
+    },
+    {
+      "componentId": "pcb_component_205",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1383",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1384",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net67",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_205-inner",
+          "networkId": "pcb_component_205-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_206",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1385",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net168",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1386",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_206-inner",
+          "networkId": "pcb_component_206-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_207",
+      "pads": [
+        {
+          "padId": "pcb_plated_hole_96",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net67",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -1.27,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_97",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 1.27,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_207-inner",
+          "networkId": "pcb_component_207-inner",
+          "type": "rect",
+          "size": {
+            "x": 4.04,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 6.08,
+        "height": 3.54
+      }
+    },
+    {
+      "componentId": "pcb_component_208",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1387",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -2.15,
+            "y": 1.905
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1388",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -2.15,
+            "y": 0.635
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1389",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -2.15,
+            "y": -0.635
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1390",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": -2.15,
+            "y": -1.905
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1391",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 2.15,
+            "y": -1.905
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1392",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 2.15,
+            "y": -0.635
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1393",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 2.15,
+            "y": 0.635
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1394",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1,
+            "y": 0.6
+          },
+          "offset": {
+            "x": 2.15,
+            "y": 1.905
+          }
+        },
+        {
+          "padId": "pcb_component_208-inner",
+          "networkId": "pcb_component_208-inner",
+          "type": "rect",
+          "size": {
+            "x": 5.3,
+            "y": 4.41
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 5.8,
+        "height": 5.545
+      }
+    },
+    {
+      "componentId": "pcb_component_209",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1395",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1396",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_209-inner",
+          "networkId": "pcb_component_209-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_210",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1397",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1398",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_210-inner",
+          "networkId": "pcb_component_210-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_211",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1399",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1400",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_211-inner",
+          "networkId": "pcb_component_211-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_212",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1401",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": -0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1402",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63",
+          "type": "rect",
+          "size": {
+            "x": 0.54,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0.51,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_212-inner",
+          "networkId": "pcb_component_212-inner",
+          "type": "rect",
+          "size": {
+            "x": 1.56,
+            "y": 0.64
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1.86,
+        "height": 0.94
+      }
+    },
+    {
+      "componentId": "pcb_component_213",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1403",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1404",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net169",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_213-inner",
+          "networkId": "pcb_component_213-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_214",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1405",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net169",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1406",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net170",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_214-inner",
+          "networkId": "pcb_component_214-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_215",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1407",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1408",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net171",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_215-inner",
+          "networkId": "pcb_component_215-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_216",
+      "pads": [
+        {
+          "padId": "pcb_smtpad_1409",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net171",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": -0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_smtpad_1410",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net172",
+          "type": "rect",
+          "size": {
+            "x": 1.025,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0.9125,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_216-inner",
+          "networkId": "pcb_component_216-inner",
+          "type": "rect",
+          "size": {
+            "x": 2.8499999999999996,
+            "y": 1.4
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 3.36,
+        "height": 1.9
+      }
+    },
+    {
+      "componentId": "pcb_component_217",
+      "pads": [
+        {
+          "padId": "pcb_plated_hole_98",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -49.53,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_99",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -46.99,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_100",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -44.45,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_101",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net89",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -41.910000000000004,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_102",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -39.370000000000005,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_103",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -36.83,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_104",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net173",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -34.29,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_105",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -31.75,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_106",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -29.21,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_107",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -26.67,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_108",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net174",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -24.130000000000003,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_109",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net175",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -21.59,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_110",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net176",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -19.05,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_111",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -16.509999999999998,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_112",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net177",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -13.969999999999999,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_113",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net178",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -11.43,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_114",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -8.89,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_115",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net179",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -6.350000000000001,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_116",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net180",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -3.8100000000000023,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_117",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": -1.2700000000000031,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_118",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net181",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 1.269999999999996,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_119",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net182",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 3.8100000000000023,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_120",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net183",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 6.350000000000001,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_121",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net184",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 8.89,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_122",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 11.43,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_123",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net185",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 13.969999999999999,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_124",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net186",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 16.510000000000005,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_125",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net187",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 19.049999999999997,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_126",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net188",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 21.590000000000003,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_127",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 24.129999999999995,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_128",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net189",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 26.67,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_129",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net190",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 29.209999999999994,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_130",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net191",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 31.75,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_131",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 34.290000000000006,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_132",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net163",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 36.83,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_133",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net164",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 39.370000000000005,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_134",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net192",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 41.91,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_135",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net193",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 44.45,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_136",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 46.989999999999995,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_plated_hole_137",
+          "networkId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net194",
+          "type": "rect",
+          "size": {
+            "x": 1.5,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 49.53,
+            "y": 0
+          }
+        },
+        {
+          "padId": "pcb_component_217-inner",
+          "networkId": "pcb_component_217-inner",
+          "type": "rect",
+          "size": {
+            "x": 100.56,
+            "y": 1.5
+          },
+          "offset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "courtyard": {
+        "offsetFromCenter": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 102.60000000000001,
+        "height": 3.54
+      }
+    }
+  ],
+  "minGap": 1,
+  "packOrderStrategy": "largest_to_smallest",
+  "packPlacementStrategy": "shortest_connection_along_outline",
+  "obstacles": [],
+  "weightedConnections": [
+    {
+      "padIds": ["pcb_smtpad_1302", "pcb_smtpad_1341"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1303", "pcb_smtpad_1343"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1342", "pcb_plated_hole_62"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1344", "pcb_plated_hole_63"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1374", "pcb_plated_hole_91"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_91", "pcb_smtpad_82"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1376", "pcb_smtpad_83"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1076", "pcb_smtpad_1098"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1098", "pcb_smtpad_1099"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1077", "pcb_smtpad_1101"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1067", "pcb_smtpad_1068"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1068", "pcb_smtpad_1089"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1034", "pcb_smtpad_1060"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1060", "pcb_smtpad_1061"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1061", "pcb_smtpad_1064"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1037", "pcb_smtpad_1065"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1029", "pcb_smtpad_1030"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1030", "pcb_smtpad_1053"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1312", "pcb_smtpad_1340"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1311", "pcb_smtpad_1339"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1305", "pcb_smtpad_1335"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1304", "pcb_smtpad_1337"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1301", "pcb_smtpad_1328"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_36", "pcb_smtpad_633"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_37", "pcb_smtpad_617"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_38", "pcb_smtpad_618"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_39", "pcb_smtpad_619"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_40", "pcb_smtpad_620"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_41", "pcb_smtpad_621"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_42", "pcb_smtpad_622"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_43", "pcb_smtpad_623"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_44", "pcb_smtpad_624"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_45", "pcb_smtpad_625"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_51", "pcb_smtpad_648"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_47", "pcb_smtpad_644"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_46", "pcb_smtpad_643"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_48", "pcb_smtpad_645"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_49", "pcb_smtpad_646"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_20", "pcb_smtpad_617"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_21", "pcb_smtpad_618"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_30", "pcb_smtpad_627"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_31", "pcb_smtpad_628"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_32", "pcb_smtpad_629"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_33", "pcb_smtpad_630"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_34", "pcb_smtpad_631"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_35", "pcb_smtpad_632"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_22", "pcb_smtpad_619"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_23", "pcb_smtpad_620"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_24", "pcb_smtpad_621"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_25", "pcb_smtpad_622"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_26", "pcb_smtpad_623"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_27", "pcb_smtpad_624"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_28", "pcb_smtpad_625"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_29", "pcb_smtpad_626"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_50", "pcb_smtpad_647"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_818", "pcb_smtpad_819"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_52", "pcb_smtpad_649"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1180", "pcb_smtpad_1211"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1181", "pcb_smtpad_1213"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1185", "pcb_plated_hole_9"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1184", "pcb_plated_hole_8"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1183", "pcb_plated_hole_7"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1182", "pcb_plated_hole_6"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1186", "pcb_plated_hole_4"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_4", "pcb_smtpad_1221"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1187", "pcb_plated_hole_5"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_5", "pcb_smtpad_1223"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_856", "pcb_smtpad_857"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_857", "pcb_smtpad_858"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_858", "pcb_smtpad_859"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_859", "pcb_smtpad_860"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_860", "pcb_smtpad_861"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_861", "pcb_smtpad_862"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_862", "pcb_smtpad_863"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_863", "pcb_smtpad_864"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_864", "pcb_smtpad_865"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_865", "pcb_smtpad_866"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_866", "pcb_smtpad_867"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_867", "pcb_smtpad_868"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_868", "pcb_smtpad_876"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_876", "pcb_smtpad_877"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_877", "pcb_smtpad_878"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_878", "pcb_smtpad_879"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_879", "pcb_smtpad_880"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_880", "pcb_smtpad_881"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_881", "pcb_smtpad_882"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_882", "pcb_smtpad_883"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_883", "pcb_smtpad_884"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_884", "pcb_smtpad_885"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_885", "pcb_smtpad_886"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_886", "pcb_smtpad_887"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_887", "pcb_smtpad_888"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_888", "pcb_smtpad_889"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_889", "pcb_smtpad_890"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_890", "pcb_smtpad_891"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_891", "pcb_smtpad_892"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_892", "pcb_smtpad_893"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_893", "pcb_smtpad_894"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_894", "pcb_smtpad_895"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_895", "pcb_smtpad_896"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_896", "pcb_smtpad_897"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_897", "pcb_smtpad_898"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_898", "pcb_smtpad_899"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_899", "pcb_smtpad_900"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_900", "pcb_smtpad_901"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_901", "pcb_smtpad_902"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_902", "pcb_smtpad_904"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_904", "pcb_smtpad_906"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_906", "pcb_smtpad_910"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_910", "pcb_smtpad_912"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_912", "pcb_smtpad_916"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_916", "pcb_smtpad_918"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_918", "pcb_smtpad_922"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_922", "pcb_smtpad_924"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_924", "pcb_smtpad_928"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_928", "pcb_smtpad_930"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_930", "pcb_smtpad_934"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_934", "pcb_smtpad_936"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_936", "pcb_smtpad_946"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_946", "pcb_smtpad_947"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_947", "pcb_smtpad_954"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_954", "pcb_smtpad_955"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_955", "pcb_smtpad_962"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_962", "pcb_smtpad_963"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_963", "pcb_smtpad_980"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_980", "pcb_smtpad_982"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_982", "pcb_smtpad_986"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_986", "pcb_smtpad_1019"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1019", "pcb_smtpad_1020"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1020", "pcb_smtpad_1026"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1026", "pcb_smtpad_1031"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1031", "pcb_smtpad_1032"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1032", "pcb_smtpad_1033"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1033", "pcb_smtpad_1046"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1046", "pcb_smtpad_1048"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1048", "pcb_smtpad_1050"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1050", "pcb_smtpad_1052"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1052", "pcb_smtpad_1056"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1056", "pcb_smtpad_1058"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1058", "pcb_smtpad_1062"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1062", "pcb_smtpad_1066"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1066", "pcb_smtpad_1069"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1069", "pcb_smtpad_1070"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1070", "pcb_smtpad_1075"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1075", "pcb_smtpad_1078"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1078", "pcb_smtpad_1084"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1084", "pcb_smtpad_1086"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1086", "pcb_smtpad_1088"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1088", "pcb_smtpad_1092"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1092", "pcb_smtpad_1094"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1094", "pcb_smtpad_1096"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1096", "pcb_smtpad_1100"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1100", "pcb_smtpad_1102"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1102", "pcb_smtpad_1104"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1104", "pcb_smtpad_1109"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1109", "pcb_smtpad_1111"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1111", "pcb_smtpad_1113"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1113", "pcb_smtpad_1118"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1118", "pcb_smtpad_1120"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1120", "pcb_smtpad_1121"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1121", "pcb_smtpad_1127"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1127", "pcb_smtpad_1129"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1129", "pcb_smtpad_1131"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1131", "pcb_smtpad_1136"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1136", "pcb_smtpad_1138"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1138", "pcb_smtpad_1140"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1140", "pcb_smtpad_1142"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1142", "pcb_smtpad_1144"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1144", "pcb_smtpad_1146"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1146", "pcb_smtpad_1148"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1148", "pcb_smtpad_1150"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1150", "pcb_smtpad_1152"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1152", "pcb_smtpad_1154"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1154", "pcb_smtpad_1156"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1156", "pcb_smtpad_1158"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1158", "pcb_smtpad_1160"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1160", "pcb_smtpad_1162"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1162", "pcb_smtpad_1166"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1166", "pcb_smtpad_1218"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1218", "pcb_smtpad_1220"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1220", "pcb_smtpad_1222"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1222", "pcb_smtpad_1224"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1224", "pcb_plated_hole_20"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_20", "pcb_smtpad_1234"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1234", "pcb_smtpad_1256"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1256", "pcb_smtpad_1258"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1258", "pcb_smtpad_1260"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1260", "pcb_smtpad_1262"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1262", "pcb_smtpad_1264"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1264", "pcb_smtpad_1266"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1266", "pcb_smtpad_1268"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1268", "pcb_smtpad_1270"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1270", "pcb_smtpad_1272"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1272", "pcb_smtpad_1274"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1274", "pcb_plated_hole_23"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_23", "pcb_plated_hole_26"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_26", "pcb_plated_hole_29"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_29", "pcb_plated_hole_32"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_32", "pcb_plated_hole_38"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_38", "pcb_plated_hole_43"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_43", "pcb_plated_hole_46"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_46", "pcb_plated_hole_49"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_49", "pcb_plated_hole_52"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_52", "pcb_plated_hole_58"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_58", "pcb_smtpad_1276"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1276", "pcb_smtpad_1278"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1278", "pcb_smtpad_1280"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1280", "pcb_smtpad_1282"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1282", "pcb_smtpad_15"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_15", "pcb_smtpad_1284"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1284", "pcb_smtpad_1286"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1286", "pcb_smtpad_1288"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1288", "pcb_smtpad_1290"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1290", "pcb_smtpad_1293"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1293", "pcb_smtpad_1306"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1306", "pcb_smtpad_1307"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1307", "pcb_smtpad_1308"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1308", "pcb_smtpad_1309"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1309", "pcb_smtpad_1310"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1310", "pcb_smtpad_1314"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1314", "pcb_smtpad_1315"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1315", "pcb_smtpad_1316"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1316", "pcb_smtpad_1317"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1317", "pcb_smtpad_1318"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1318", "pcb_smtpad_1319"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1319", "pcb_smtpad_1320"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1320", "pcb_smtpad_1321"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1321", "pcb_smtpad_1322"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1322", "pcb_smtpad_1330"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1330", "pcb_smtpad_1332"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1332", "pcb_smtpad_1334"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1334", "pcb_smtpad_1336"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1336", "pcb_smtpad_1338"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1338", "pcb_plated_hole_64"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_64", "pcb_smtpad_1346"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1346", "pcb_smtpad_1351"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1351", "pcb_smtpad_1353"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1353", "pcb_plated_hole_68"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_68", "pcb_plated_hole_69"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_69", "pcb_plated_hole_76"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_76", "pcb_smtpad_1358"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1358", "pcb_smtpad_16"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_16", "pcb_smtpad_1367"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1367", "pcb_smtpad_1368"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1368", "pcb_smtpad_1369"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1369", "pcb_smtpad_1370"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1370", "pcb_plated_hole_82"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_82", "pcb_plated_hole_84"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_84", "pcb_plated_hole_88"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_88", "pcb_smtpad_1375"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1375", "pcb_smtpad_1377"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1377", "pcb_plated_hole_90"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_90", "pcb_smtpad_1379"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1379", "pcb_smtpad_1386"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1386", "pcb_plated_hole_97"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_97", "pcb_smtpad_1387"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1387", "pcb_smtpad_1388"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1388", "pcb_smtpad_1389"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1389", "pcb_smtpad_1390"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1390", "pcb_smtpad_1393"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1393", "pcb_plated_hole_103"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_103", "pcb_plated_hole_106"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_106", "pcb_plated_hole_111"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_111", "pcb_plated_hole_117"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_117", "pcb_plated_hole_122"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_122", "pcb_plated_hole_127"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_127", "pcb_plated_hole_131"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_131", "pcb_smtpad_17"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_17", "pcb_plated_hole_136"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_136", "pcb_smtpad_18"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_18", "pcb_smtpad_19"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_19", "pcb_smtpad_530"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_530", "pcb_smtpad_532"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_532", "pcb_smtpad_534"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_534", "pcb_smtpad_536"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_536", "pcb_smtpad_538"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_538", "pcb_smtpad_540"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_540", "pcb_smtpad_542"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_542", "pcb_smtpad_544"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_544", "pcb_smtpad_546"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_546", "pcb_smtpad_548"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_548", "pcb_smtpad_550"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_550", "pcb_smtpad_552"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_552", "pcb_smtpad_554"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_554", "pcb_smtpad_556"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_556", "pcb_smtpad_558"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_558", "pcb_smtpad_560"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_560", "pcb_smtpad_562"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_562", "pcb_smtpad_564"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_564", "pcb_smtpad_566"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_566", "pcb_smtpad_568"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_568", "pcb_smtpad_570"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_570", "pcb_smtpad_572"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_572", "pcb_smtpad_574"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_574", "pcb_smtpad_576"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_576", "pcb_smtpad_578"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_578", "pcb_smtpad_580"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_580", "pcb_smtpad_582"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_582", "pcb_smtpad_584"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_584", "pcb_smtpad_586"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_586", "pcb_smtpad_588"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_588", "pcb_smtpad_590"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_590", "pcb_smtpad_592"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_592", "pcb_smtpad_594"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_594", "pcb_smtpad_596"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_596", "pcb_smtpad_598"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_598", "pcb_smtpad_600"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_600", "pcb_smtpad_602"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_602", "pcb_smtpad_604"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_604", "pcb_smtpad_606"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_606", "pcb_smtpad_608"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_608", "pcb_smtpad_610"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_610", "pcb_smtpad_612"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_612", "pcb_smtpad_614"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_614", "pcb_smtpad_616"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_616", "pcb_smtpad_656"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_656", "pcb_smtpad_657"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_657", "pcb_smtpad_658"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_658", "pcb_smtpad_659"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_659", "pcb_smtpad_660"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_660", "pcb_smtpad_820"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_820", "pcb_smtpad_822"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_822", "pcb_smtpad_824"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_824", "pcb_smtpad_826"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_826", "pcb_smtpad_828"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_828", "pcb_smtpad_830"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_830", "pcb_smtpad_832"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_832", "pcb_smtpad_834"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_838", "pcb_smtpad_839"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_839", "pcb_smtpad_840"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1253", "pcb_plated_hole_53"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_53", "pcb_smtpad_1289"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1251", "pcb_plated_hole_51"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_51", "pcb_smtpad_1287"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1249", "pcb_plated_hole_50"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_50", "pcb_smtpad_1285"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1285", "pcb_smtpad_91"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1247", "pcb_plated_hole_48"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_48", "pcb_smtpad_1283"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1283", "pcb_smtpad_90"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1245", "pcb_plated_hole_47"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_47", "pcb_smtpad_1281"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1243", "pcb_plated_hole_45"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_45", "pcb_smtpad_1279"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1241", "pcb_plated_hole_44"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_44", "pcb_smtpad_1277"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1239", "pcb_plated_hole_42"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_42", "pcb_smtpad_1275"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1250", "pcb_smtpad_1265"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1265", "pcb_plated_hole_30"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1248", "pcb_smtpad_1263"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1263", "pcb_plated_hole_28"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1246", "pcb_smtpad_1261"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1261", "pcb_plated_hole_27"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1244", "pcb_smtpad_1259"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1259", "pcb_plated_hole_25"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1242", "pcb_smtpad_1257"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1257", "pcb_plated_hole_24"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1240", "pcb_smtpad_1255"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1255", "pcb_plated_hole_22"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1254", "pcb_smtpad_1269"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1269", "pcb_plated_hole_33"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1252", "pcb_smtpad_1267"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1267", "pcb_plated_hole_31"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_869", "pcb_smtpad_938"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_938", "pcb_smtpad_1271"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1271", "pcb_plated_hole_36"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_36", "pcb_smtpad_1299"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1299", "pcb_smtpad_1324"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1324", "pcb_smtpad_1392"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1392", "pcb_smtpad_1396"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1396", "pcb_smtpad_1400"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1400", "pcb_plated_hole_102"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_102", "pcb_smtpad_76"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_870", "pcb_smtpad_940"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_940", "pcb_smtpad_1273"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1273", "pcb_plated_hole_37"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_37", "pcb_smtpad_1300"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1300", "pcb_smtpad_1326"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1326", "pcb_smtpad_1391"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1391", "pcb_smtpad_1398"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1398", "pcb_smtpad_1402"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1402", "pcb_plated_hole_100"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_100", "pcb_smtpad_77"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1022", "pcb_smtpad_1025"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1025", "pcb_smtpad_1028"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_83", "pcb_smtpad_84"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_87", "pcb_smtpad_86"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_85", "pcb_smtpad_87"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_81", "pcb_smtpad_85"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1408", "pcb_smtpad_1409"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1404", "pcb_smtpad_1405"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_14", "pcb_smtpad_1238"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_16", "pcb_smtpad_1225"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_17", "pcb_smtpad_1227"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_18", "pcb_smtpad_1229"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_19", "pcb_smtpad_1231"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1226", "pcb_smtpad_1228"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1228", "pcb_smtpad_1230"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1230", "pcb_smtpad_1232"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1232", "pcb_smtpad_1233"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_12", "pcb_smtpad_1236"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_949", "pcb_smtpad_979"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_979", "pcb_smtpad_983"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_983", "pcb_smtpad_1017"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_957", "pcb_smtpad_981"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_981", "pcb_smtpad_984"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_984", "pcb_smtpad_1018"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_871", "pcb_smtpad_942"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_872", "pcb_smtpad_944"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_847", "pcb_smtpad_848"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_848", "pcb_smtpad_925"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_849", "pcb_smtpad_850"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_850", "pcb_smtpad_931"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_907", "pcb_smtpad_841"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_841", "pcb_smtpad_842"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_845", "pcb_smtpad_846"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_846", "pcb_smtpad_919"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_843", "pcb_smtpad_844"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_844", "pcb_smtpad_913"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_873", "pcb_smtpad_945"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_945", "pcb_smtpad_1378"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1378", "pcb_smtpad_1384"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1384", "pcb_plated_hole_96"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_96", "pcb_smtpad_81"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1382", "pcb_smtpad_1385"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1173", "pcb_smtpad_66"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1174", "pcb_smtpad_67"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1175", "pcb_smtpad_1215"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1215", "pcb_smtpad_72"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1176", "pcb_smtpad_1217"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1217", "pcb_smtpad_73"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1177", "pcb_smtpad_1219"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1219", "pcb_smtpad_74"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1178", "pcb_smtpad_75"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1167", "pcb_smtpad_64"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1168", "pcb_smtpad_65"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1169", "pcb_smtpad_68"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1170", "pcb_smtpad_69"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1171", "pcb_smtpad_70"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1172", "pcb_smtpad_71"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1295", "pcb_smtpad_93"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1296", "pcb_smtpad_94"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1294", "pcb_smtpad_92"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1298", "pcb_smtpad_96"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1297", "pcb_smtpad_95"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_77", "pcb_plated_hole_132"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_78", "pcb_plated_hole_133"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_89", "pcb_smtpad_1380"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1380", "pcb_smtpad_80"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_903", "pcb_smtpad_905"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_905", "pcb_smtpad_1024"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1024", "pcb_smtpad_1036"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1036", "pcb_smtpad_1039"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1039", "pcb_smtpad_1040"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1040", "pcb_smtpad_1041"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1041", "pcb_smtpad_1045"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1045", "pcb_smtpad_1047"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1047", "pcb_smtpad_1049"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1049", "pcb_smtpad_1051"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1051", "pcb_smtpad_1071"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1071", "pcb_smtpad_1072"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1072", "pcb_smtpad_1073"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1073", "pcb_smtpad_1083"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1083", "pcb_smtpad_1085"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1085", "pcb_smtpad_1087"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1087", "pcb_smtpad_1139"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1139", "pcb_smtpad_1141"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1141", "pcb_plated_hole_59"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_59", "pcb_smtpad_1348"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1348", "pcb_plated_hole_99"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_99", "pcb_plated_hole_101"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_101", "pcb_smtpad_835"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_835", "pcb_smtpad_836"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_836", "pcb_smtpad_837"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1359", "pcb_plated_hole_107"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_107", "pcb_smtpad_79"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1360", "pcb_plated_hole_105"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_105", "pcb_smtpad_78"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_948", "pcb_smtpad_953"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_953", "pcb_smtpad_956"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_956", "pcb_smtpad_961"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_961", "pcb_smtpad_985"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_985", "pcb_smtpad_1021"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1021", "pcb_smtpad_1023"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1023", "pcb_smtpad_1027"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_951", "pcb_smtpad_959"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_959", "pcb_smtpad_1016"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1016", "pcb_smtpad_1354"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1354", "pcb_smtpad_1355"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1355", "pcb_plated_hole_66"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_66", "pcb_smtpad_89"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_950", "pcb_smtpad_958"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_958", "pcb_smtpad_1015"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1015", "pcb_smtpad_1352"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1352", "pcb_smtpad_1357"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1357", "pcb_plated_hole_67"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_67", "pcb_smtpad_88"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1345", "pcb_smtpad_1350"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1349", "pcb_smtpad_1356"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1356", "pcb_plated_hole_65"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_10", "pcb_smtpad_854"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_854", "pcb_smtpad_875"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_875", "pcb_smtpad_926"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_926", "pcb_smtpad_927"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_927", "pcb_smtpad_929"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_929", "pcb_smtpad_11"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_11", "pcb_smtpad_1079"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1079", "pcb_smtpad_1090"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1090", "pcb_smtpad_1091"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1091", "pcb_smtpad_1093"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1093", "pcb_smtpad_1095"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1095", "pcb_smtpad_1097"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1097", "pcb_smtpad_1103"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1103", "pcb_smtpad_1105"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1105", "pcb_smtpad_1108"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1108", "pcb_smtpad_1153"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1153", "pcb_smtpad_1155"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1155", "pcb_smtpad_1157"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1157", "pcb_smtpad_1159"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1159", "pcb_smtpad_1161"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1161", "pcb_smtpad_1165"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1165", "pcb_smtpad_1212"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1212", "pcb_smtpad_1214"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1214", "pcb_smtpad_1216"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1216", "pcb_smtpad_581"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_581", "pcb_smtpad_583"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_583", "pcb_smtpad_585"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_585", "pcb_smtpad_587"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_587", "pcb_smtpad_589"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_589", "pcb_smtpad_591"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_591", "pcb_smtpad_593"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_593", "pcb_smtpad_595"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_855", "pcb_smtpad_874"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_874", "pcb_smtpad_932"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_932", "pcb_smtpad_933"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_933", "pcb_smtpad_935"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_935", "pcb_smtpad_937"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_937", "pcb_smtpad_939"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_939", "pcb_smtpad_941"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_941", "pcb_smtpad_943"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_943", "pcb_smtpad_1038"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1038", "pcb_smtpad_12"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_12", "pcb_smtpad_1054"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1054", "pcb_smtpad_1055"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1055", "pcb_smtpad_1057"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1057", "pcb_smtpad_1059"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1059", "pcb_smtpad_1063"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1063", "pcb_smtpad_1112"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1112", "pcb_smtpad_1114"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1114", "pcb_smtpad_1117"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1117", "pcb_smtpad_1123"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1123", "pcb_smtpad_1125"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1125", "pcb_smtpad_1126"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1126", "pcb_smtpad_1130"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1130", "pcb_smtpad_1132"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1132", "pcb_smtpad_1135"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1135", "pcb_smtpad_13"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_13", "pcb_smtpad_1143"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1143", "pcb_smtpad_1145"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1145", "pcb_smtpad_1147"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1147", "pcb_smtpad_1149"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1149", "pcb_smtpad_1151"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1151", "pcb_smtpad_1163"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1163", "pcb_smtpad_1164"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1164", "pcb_plated_hole_10"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_10", "pcb_plated_hole_11"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_11", "pcb_smtpad_14"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_14", "pcb_smtpad_1235"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1235", "pcb_smtpad_1237"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1237", "pcb_plated_hole_74"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_74", "pcb_smtpad_1361"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1361", "pcb_smtpad_1366"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1366", "pcb_smtpad_1373"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1373", "pcb_plated_hole_80"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_80", "pcb_plated_hole_92"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_92", "pcb_smtpad_1381"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1381", "pcb_smtpad_1383"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1383", "pcb_smtpad_1394"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1394", "pcb_smtpad_1395"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1395", "pcb_smtpad_1397"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1397", "pcb_smtpad_1399"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1399", "pcb_smtpad_1401"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1401", "pcb_smtpad_1403"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1403", "pcb_smtpad_1407"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1407", "pcb_plated_hole_98"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_98", "pcb_plated_hole_114"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_114", "pcb_smtpad_597"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_597", "pcb_smtpad_599"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_599", "pcb_smtpad_601"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_601", "pcb_smtpad_603"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_603", "pcb_smtpad_605"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_605", "pcb_smtpad_607"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_0", "pcb_smtpad_1"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1", "pcb_smtpad_851"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_851", "pcb_smtpad_908"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_908", "pcb_smtpad_909"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_909", "pcb_smtpad_911"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_911", "pcb_smtpad_2"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_2", "pcb_smtpad_529"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_529", "pcb_smtpad_531"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_531", "pcb_smtpad_533"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_533", "pcb_smtpad_535"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_535", "pcb_smtpad_537"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_537", "pcb_smtpad_539"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_539", "pcb_smtpad_541"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_541", "pcb_smtpad_543"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1122", "pcb_smtpad_1128"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1128", "pcb_smtpad_1291"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1291", "pcb_smtpad_1292"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1292", "pcb_smtpad_1313"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1313", "pcb_smtpad_1323"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1323", "pcb_smtpad_1325"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1325", "pcb_smtpad_1327"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1327", "pcb_smtpad_1329"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1329", "pcb_smtpad_1331"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1331", "pcb_smtpad_1333"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1107", "pcb_smtpad_1110"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1110", "pcb_smtpad_653"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_653", "pcb_smtpad_654"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_654", "pcb_smtpad_655"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_655", "pcb_smtpad_821"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_821", "pcb_smtpad_829"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_829", "pcb_smtpad_831"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_831", "pcb_smtpad_833"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_853", "pcb_smtpad_920"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_920", "pcb_smtpad_921"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_921", "pcb_smtpad_923"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_923", "pcb_smtpad_561"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_561", "pcb_smtpad_563"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_563", "pcb_smtpad_565"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_565", "pcb_smtpad_567"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_567", "pcb_smtpad_569"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_569", "pcb_smtpad_571"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_571", "pcb_smtpad_573"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_573", "pcb_smtpad_575"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_575", "pcb_smtpad_577"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_577", "pcb_smtpad_579"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_579", "pcb_smtpad_6"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_6", "pcb_smtpad_650"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_650", "pcb_smtpad_651"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_651", "pcb_smtpad_652"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_652", "pcb_smtpad_7"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_7", "pcb_smtpad_8"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_8", "pcb_smtpad_817"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_817", "pcb_smtpad_823"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_823", "pcb_smtpad_825"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_825", "pcb_smtpad_827"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1134", "pcb_smtpad_1137"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_1116", "pcb_smtpad_1119"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_852", "pcb_smtpad_914"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_914", "pcb_smtpad_915"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_915", "pcb_smtpad_917"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_917", "pcb_smtpad_3"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_3", "pcb_smtpad_4"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_4", "pcb_smtpad_5"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_5", "pcb_smtpad_545"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_545", "pcb_smtpad_547"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_547", "pcb_smtpad_549"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_549", "pcb_smtpad_551"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_551", "pcb_smtpad_553"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_553", "pcb_smtpad_555"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_555", "pcb_smtpad_557"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_557", "pcb_smtpad_559"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_0", "pcb_smtpad_609"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_609", "pcb_smtpad_97"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_1", "pcb_smtpad_611"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_smtpad_611", "pcb_smtpad_98"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_2", "pcb_smtpad_613"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    },
+    {
+      "padIds": ["pcb_plated_hole_3", "pcb_smtpad_615"],
+      "weight": 1,
+      "ignoreWeakConnections": true
+    }
+  ],
+  "orderStrategy": "largest_to_smallest",
+  "placementStrategy": "minimum_sum_squared_distance_to_network",
+  "bounds": {
+    "minX": -110,
+    "maxX": 110,
+    "minY": -75,
+    "maxY": 75
+  }
+}


### PR DESCRIPTION
## What changed

- adds the exact 825-trace tscircuit source that caused PCB packing to appear stuck
- adds the exact `PackInput` captured at the `PackSolver2` boundary
- adds a fast fixture-integrity test and an opt-in full-solver reproduction

The captured input contains 218 components, 1,767 pads, and 670 weighted connections.

## Why

This real-world board exposes severe packing slowdown as the placed-component outline grows and candidate evaluation repeatedly processes a large pad and weighted-connection set. Keeping both the source circuit and boundary input makes it possible to profile improvements directly in `calculate-packing` without rerunning the full tscircuit pipeline.

Run the slow reproduction with:

```sh
RUN_SLOW_PACKING_REPRO=1 bun test \
  tests/repros/repro-large-weighted-connections.test.ts
```

The full solve is opt-in so ordinary CI does not inherit the current multi-minute behavior.

## Validation

- `bun test tests/repros/repro-large-weighted-connections.test.ts`
- `bun run typecheck`
- Biome formatting check for all three added files
