### PR TITLE
Reject unfit candidates before network mapping

### DIFF
--- a/lib/OutlineSegmentCandidatePointSolver/OutlineSegmentCandidatePointSolver.ts
+++ b/lib/OutlineSegmentCandidatePointSolver/OutlineSegmentCandidatePointSolver.ts
@@ -129,10 +129,6 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
   }
 
   override _setup() {
-    // Get pad offset points and target point mappings
-    const { offsetPadPoints, targetPointMap } =
-      this.getNetworkTargetPointMappings()
-
     const [p1, p2] = this.outlineSegment
 
     // Create constraint function to keep position on outline segment and avoid collision
@@ -283,6 +279,11 @@ export class OutlineSegmentCandidatePointSolver extends BaseSolver {
       x: (vp1.x + vp2.x) / 2,
       y: (vp1.y + vp2.y) / 2,
     })
+
+    // Network targets do not affect whether the component can fit along this
+    // outline segment, so defer their construction until after fit rejection.
+    const { offsetPadPoints, targetPointMap } =
+      this.getNetworkTargetPointMappings()
 
     if (this.packStrategy === "minimum_closest_sum_squared_distance") {
       this.twoPhaseIrlsSolver = new TwoPhaseIrlsSolver({

--- a/tests/outline-candidate-fit-rejection.test.ts
+++ b/tests/outline-candidate-fit-rejection.test.ts
@@ -1,0 +1,74 @@
+import { expect, spyOn, test } from "bun:test"
+import { LargestRectOutsideOutlineFromPointSolver } from "../lib/LargestRectOutsideOutlineFromPointSolver"
+import { OutlineSegmentCandidatePointSolver } from "../lib/OutlineSegmentCandidatePointSolver/OutlineSegmentCandidatePointSolver"
+import type { InputComponent } from "../lib/types"
+
+test("rejects an unfit outline candidate before building network targets", () => {
+  const componentToPack: InputComponent = {
+    componentId: "component-to-pack",
+    pads: [
+      {
+        padId: "pad-to-pack",
+        networkId: "signal",
+        type: "rect",
+        offset: { x: 0, y: 0 },
+        size: { x: 10, y: 10 },
+      },
+    ],
+  }
+
+  const solver = new OutlineSegmentCandidatePointSolver({
+    outlineSegment: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+    ],
+    ccwFullOutline: [
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ],
+      [
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+      ],
+      [
+        { x: 10, y: 10 },
+        { x: 0, y: 10 },
+      ],
+      [
+        { x: 0, y: 10 },
+        { x: 0, y: 0 },
+      ],
+    ],
+    componentRotationDegrees: 0,
+    packStrategy: "minimum_sum_distance_to_network",
+    minGap: 1,
+    packedComponents: [],
+    componentToPack,
+  })
+
+  let didBuildNetworkTargets = false
+  Object.defineProperty(solver, "getNetworkTargetPointMappings", {
+    value: () => {
+      didBuildNetworkTargets = true
+      return { offsetPadPoints: [], targetPointMap: new Map() }
+    },
+  })
+
+  const getLargestRectBoundsSpy = spyOn(
+    LargestRectOutsideOutlineFromPointSolver.prototype,
+    "getLargestRectBounds",
+  ).mockReturnValue({ minX: 0, minY: 0, maxX: 5, maxY: 5 })
+
+  try {
+    solver.setup()
+
+    expect(solver.failed).toBe(true)
+    expect(solver.error).toBe(
+      "There is nowhere for the component to fit along this outline section",
+    )
+    expect(didBuildNetworkTargets).toBe(false)
+  } finally {
+    getLargestRectBoundsSpy.mockRestore()
+  }
+})


### PR DESCRIPTION
## Summary

- reject outline candidates that cannot fit before constructing their network target mappings
- add a focused regression test that verifies an unfit candidate never builds network targets

## Why

Network target mappings depend on the component, rotation, and packed components—not on whether the current outline segment has enough room. Building those mappings before the geometric fit check wasted the most expensive connectivity work for candidates that were immediately rejected.

On the large weighted-connections repro, the same 100,000-step workload now builds 31,394 target mappings instead of 50,902, skipping 19,508 unnecessary builds. Runtime in the instrumented run decreased from about 69.85s to 55.97s. The repro still reaches the existing global iteration limit; that is separate from this focused change.

## Validation

- `bun run typecheck`
- `bun test tests/outline-candidate-fit-rejection.test.ts lib/OutlineSegmentCandidatePointSolver.test.ts tests/PackSolver2.test.ts tests/PackSolver2_01.test.ts` (6 pass, 2 pre-existing skips)
- Biome format check on the two changed files
