### PR TITLE
Index weighted connection lookups

### DIFF
--- a/lib/utils/createWeightedConnectionIndex.ts
+++ b/lib/utils/createWeightedConnectionIndex.ts
@@ -1,0 +1,42 @@
+import type { PackInput } from "../types"
+
+export type WeightedConnections = NonNullable<PackInput["weightedConnections"]>
+
+export interface WeightedConnectionIndex {
+  explicitlyConnectedPadIdsByPadId: Map<string, Set<string>>
+  padIdsRejectingWeakConnections: Set<string>
+}
+
+/**
+ * Builds constant-time lookups for weighted-connection checks.
+ */
+export function createWeightedConnectionIndex(
+  weightedConnections: WeightedConnections,
+): WeightedConnectionIndex {
+  const explicitlyConnectedPadIdsByPadId = new Map<string, Set<string>>()
+  const padIdsRejectingWeakConnections = new Set<string>()
+
+  for (const { padIds, ignoreWeakConnections } of weightedConnections) {
+    for (const padId of padIds) {
+      let explicitlyConnectedPadIds =
+        explicitlyConnectedPadIdsByPadId.get(padId)
+      if (!explicitlyConnectedPadIds) {
+        explicitlyConnectedPadIds = new Set<string>()
+        explicitlyConnectedPadIdsByPadId.set(padId, explicitlyConnectedPadIds)
+      }
+
+      for (const connectedPadId of padIds) {
+        explicitlyConnectedPadIds.add(connectedPadId)
+      }
+
+      if (ignoreWeakConnections === true) {
+        padIdsRejectingWeakConnections.add(padId)
+      }
+    }
+  }
+
+  return {
+    explicitlyConnectedPadIdsByPadId,
+    padIdsRejectingWeakConnections,
+  }
+}

--- a/lib/utils/getStronglyConnectedPadIds.ts
+++ b/lib/utils/getStronglyConnectedPadIds.ts
@@ -1,0 +1,27 @@
+import type { PackInput } from "../types"
+import { getWeightedConnectionIndex } from "./getWeightedConnectionIndex"
+
+/**
+ * Gets all pad IDs that have strong connections to a given pad.
+ *
+ * @param padId - The pad ID to find strong connections for
+ * @param weightedConnections - Optional weighted connections from PackInput
+ * @returns Set of pad IDs that have strong connections to the given pad
+ */
+export function getStronglyConnectedPadIds(
+  padId: string,
+  weightedConnections?: PackInput["weightedConnections"],
+): Set<string> {
+  // No weightedConnections = return empty set (will use networkId fallback)
+  if (!weightedConnections || weightedConnections.length === 0) {
+    return new Set<string>()
+  }
+
+  const index = getWeightedConnectionIndex(weightedConnections)
+  const connectedPadIds = new Set(
+    index.explicitlyConnectedPadIdsByPadId.get(padId),
+  )
+  connectedPadIds.delete(padId)
+
+  return connectedPadIds
+}

--- a/lib/utils/getWeightedConnectionIndex.ts
+++ b/lib/utils/getWeightedConnectionIndex.ts
@@ -1,0 +1,25 @@
+import {
+  createWeightedConnectionIndex,
+  type WeightedConnectionIndex,
+  type WeightedConnections,
+} from "./createWeightedConnectionIndex"
+
+const weightedConnectionIndexCache = new WeakMap<
+  WeightedConnections,
+  WeightedConnectionIndex
+>()
+
+/**
+ * Reuses an index for repeated checks against the same weighted-connections
+ * array. Pack inputs are treated as immutable while a layout is being solved.
+ */
+export function getWeightedConnectionIndex(
+  weightedConnections: WeightedConnections,
+): WeightedConnectionIndex {
+  const cachedIndex = weightedConnectionIndexCache.get(weightedConnections)
+  if (cachedIndex) return cachedIndex
+
+  const index = createWeightedConnectionIndex(weightedConnections)
+  weightedConnectionIndexCache.set(weightedConnections, index)
+  return index
+}

--- a/lib/utils/isStrongConnection.ts
+++ b/lib/utils/isStrongConnection.ts
@@ -1,65 +1,5 @@
 import type { PackInput } from "../types"
-
-type WeightedConnections = NonNullable<PackInput["weightedConnections"]>
-
-export interface WeightedConnectionIndex {
-  explicitlyConnectedPadIdsByPadId: Map<string, Set<string>>
-  padIdsRejectingWeakConnections: Set<string>
-}
-
-const weightedConnectionIndexCache = new WeakMap<
-  WeightedConnections,
-  WeightedConnectionIndex
->()
-
-/**
- * Builds constant-time lookups for weighted-connection checks.
- */
-export function createWeightedConnectionIndex(
-  weightedConnections: WeightedConnections,
-): WeightedConnectionIndex {
-  const explicitlyConnectedPadIdsByPadId = new Map<string, Set<string>>()
-  const padIdsRejectingWeakConnections = new Set<string>()
-
-  for (const { padIds, ignoreWeakConnections } of weightedConnections) {
-    for (const padId of padIds) {
-      let explicitlyConnectedPadIds =
-        explicitlyConnectedPadIdsByPadId.get(padId)
-      if (!explicitlyConnectedPadIds) {
-        explicitlyConnectedPadIds = new Set<string>()
-        explicitlyConnectedPadIdsByPadId.set(padId, explicitlyConnectedPadIds)
-      }
-
-      for (const connectedPadId of padIds) {
-        explicitlyConnectedPadIds.add(connectedPadId)
-      }
-
-      if (ignoreWeakConnections === true) {
-        padIdsRejectingWeakConnections.add(padId)
-      }
-    }
-  }
-
-  return {
-    explicitlyConnectedPadIdsByPadId,
-    padIdsRejectingWeakConnections,
-  }
-}
-
-/**
- * Reuses an index for repeated checks against the same weighted-connections
- * array. Pack inputs are treated as immutable while a layout is being solved.
- */
-export function getWeightedConnectionIndex(
-  weightedConnections: WeightedConnections,
-): WeightedConnectionIndex {
-  const cachedIndex = weightedConnectionIndexCache.get(weightedConnections)
-  if (cachedIndex) return cachedIndex
-
-  const index = createWeightedConnectionIndex(weightedConnections)
-  weightedConnectionIndexCache.set(weightedConnections, index)
-  return index
-}
+import { getWeightedConnectionIndex } from "./getWeightedConnectionIndex"
 
 /**
  * Checks if two pads have a "strong" (weighted) connection.
@@ -100,29 +40,4 @@ export function isStrongConnection(
     index.padIdsRejectingWeakConnections.has(pad2Id)
 
   return !eitherPadRejectsWeakConnections
-}
-
-/**
- * Gets all pad IDs that have strong connections to a given pad.
- *
- * @param padId - The pad ID to find strong connections for
- * @param weightedConnections - Optional weighted connections from PackInput
- * @returns Set of pad IDs that have strong connections to the given pad
- */
-export function getStronglyConnectedPadIds(
-  padId: string,
-  weightedConnections?: PackInput["weightedConnections"],
-): Set<string> {
-  // No weightedConnections = return empty set (will use networkId fallback)
-  if (!weightedConnections || weightedConnections.length === 0) {
-    return new Set<string>()
-  }
-
-  const index = getWeightedConnectionIndex(weightedConnections)
-  const connectedPadIds = new Set(
-    index.explicitlyConnectedPadIdsByPadId.get(padId),
-  )
-  connectedPadIds.delete(padId)
-
-  return connectedPadIds
 }

--- a/lib/utils/isStrongConnection.ts
+++ b/lib/utils/isStrongConnection.ts
@@ -1,5 +1,66 @@
 import type { PackInput } from "../types"
 
+type WeightedConnections = NonNullable<PackInput["weightedConnections"]>
+
+export interface WeightedConnectionIndex {
+  explicitlyConnectedPadIdsByPadId: Map<string, Set<string>>
+  padIdsRejectingWeakConnections: Set<string>
+}
+
+const weightedConnectionIndexCache = new WeakMap<
+  WeightedConnections,
+  WeightedConnectionIndex
+>()
+
+/**
+ * Builds constant-time lookups for weighted-connection checks.
+ */
+export function createWeightedConnectionIndex(
+  weightedConnections: WeightedConnections,
+): WeightedConnectionIndex {
+  const explicitlyConnectedPadIdsByPadId = new Map<string, Set<string>>()
+  const padIdsRejectingWeakConnections = new Set<string>()
+
+  for (const { padIds, ignoreWeakConnections } of weightedConnections) {
+    for (const padId of padIds) {
+      let explicitlyConnectedPadIds =
+        explicitlyConnectedPadIdsByPadId.get(padId)
+      if (!explicitlyConnectedPadIds) {
+        explicitlyConnectedPadIds = new Set<string>()
+        explicitlyConnectedPadIdsByPadId.set(padId, explicitlyConnectedPadIds)
+      }
+
+      for (const connectedPadId of padIds) {
+        explicitlyConnectedPadIds.add(connectedPadId)
+      }
+
+      if (ignoreWeakConnections === true) {
+        padIdsRejectingWeakConnections.add(padId)
+      }
+    }
+  }
+
+  return {
+    explicitlyConnectedPadIdsByPadId,
+    padIdsRejectingWeakConnections,
+  }
+}
+
+/**
+ * Reuses an index for repeated checks against the same weighted-connections
+ * array. Pack inputs are treated as immutable while a layout is being solved.
+ */
+export function getWeightedConnectionIndex(
+  weightedConnections: WeightedConnections,
+): WeightedConnectionIndex {
+  const cachedIndex = weightedConnectionIndexCache.get(weightedConnections)
+  if (cachedIndex) return cachedIndex
+
+  const index = createWeightedConnectionIndex(weightedConnections)
+  weightedConnectionIndexCache.set(weightedConnections, index)
+  return index
+}
+
 /**
  * Checks if two pads have a "strong" (weighted) connection.
  *
@@ -25,22 +86,18 @@ export function isStrongConnection(
     return true
   }
 
-  const pairIsExplicitlyWeighted = weightedConnections.some(({ padIds }) => {
-    return padIds.includes(pad1Id) && padIds.includes(pad2Id)
-  })
+  const index = getWeightedConnectionIndex(weightedConnections)
+  const pairIsExplicitlyWeighted = index.explicitlyConnectedPadIdsByPadId
+    .get(pad1Id)
+    ?.has(pad2Id)
 
   if (pairIsExplicitlyWeighted) {
     return true
   }
 
-  const eitherPadRejectsWeakConnections = weightedConnections.some(
-    ({ padIds, ignoreWeakConnections }) => {
-      const containsEitherPad =
-        padIds.includes(pad1Id) || padIds.includes(pad2Id)
-
-      return ignoreWeakConnections === true && containsEitherPad
-    },
-  )
+  const eitherPadRejectsWeakConnections =
+    index.padIdsRejectingWeakConnections.has(pad1Id) ||
+    index.padIdsRejectingWeakConnections.has(pad2Id)
 
   return !eitherPadRejectsWeakConnections
 }
@@ -56,22 +113,16 @@ export function getStronglyConnectedPadIds(
   padId: string,
   weightedConnections?: PackInput["weightedConnections"],
 ): Set<string> {
-  const connectedPadIds = new Set<string>()
-
   // No weightedConnections = return empty set (will use networkId fallback)
   if (!weightedConnections || weightedConnections.length === 0) {
-    return connectedPadIds
+    return new Set<string>()
   }
 
-  for (const wc of weightedConnections) {
-    if (wc.padIds.includes(padId)) {
-      for (const otherPadId of wc.padIds) {
-        if (otherPadId !== padId) {
-          connectedPadIds.add(otherPadId)
-        }
-      }
-    }
-  }
+  const index = getWeightedConnectionIndex(weightedConnections)
+  const connectedPadIds = new Set(
+    index.explicitlyConnectedPadIdsByPadId.get(padId),
+  )
+  connectedPadIds.delete(padId)
 
   return connectedPadIds
 }

--- a/tests/is-strong-connection.test.ts
+++ b/tests/is-strong-connection.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "bun:test"
-import { isStrongConnection } from "../lib/utils/isStrongConnection"
+import {
+  getStronglyConnectedPadIds,
+  getWeightedConnectionIndex,
+  isStrongConnection,
+} from "../lib/utils/isStrongConnection"
 
 test("all connections are strong without weighted connections", () => {
   expect(isStrongConnection("pad1", "pad2")).toBe(true)
@@ -51,4 +55,33 @@ test("participating pads keep unlisted connections when weak connections are all
       },
     ]),
   ).toBe(true)
+})
+
+test("reuses one weighted-connection index for repeated checks", () => {
+  const weightedConnections = [
+    {
+      padIds: ["pad1", "pad2"],
+      weight: 2,
+      ignoreWeakConnections: true,
+    },
+  ]
+
+  expect(getWeightedConnectionIndex(weightedConnections)).toBe(
+    getWeightedConnectionIndex(weightedConnections),
+  )
+})
+
+test("indexes every pair in a multi-pad weighted connection", () => {
+  const weightedConnections = [
+    {
+      padIds: ["pad1", "pad2", "pad3"],
+      weight: 2,
+      ignoreWeakConnections: true,
+    },
+  ]
+
+  expect(isStrongConnection("pad1", "pad3", weightedConnections)).toBe(true)
+  expect(getStronglyConnectedPadIds("pad2", weightedConnections)).toEqual(
+    new Set(["pad1", "pad3"]),
+  )
 })

--- a/tests/is-strong-connection.test.ts
+++ b/tests/is-strong-connection.test.ts
@@ -1,9 +1,7 @@
 import { expect, test } from "bun:test"
-import {
-  getStronglyConnectedPadIds,
-  getWeightedConnectionIndex,
-  isStrongConnection,
-} from "../lib/utils/isStrongConnection"
+import { getStronglyConnectedPadIds } from "../lib/utils/getStronglyConnectedPadIds"
+import { getWeightedConnectionIndex } from "../lib/utils/getWeightedConnectionIndex"
+import { isStrongConnection } from "../lib/utils/isStrongConnection"
 
 test("all connections are strong without weighted connections", () => {
   expect(isStrongConnection("pad1", "pad2")).toBe(true)


### PR DESCRIPTION
## Summary

- build an adjacency index for explicitly weighted pad connections
- build a set for pads that reject weak connections
- cache the index by the immutable weighted-connections array
- use constant-time lookups in both `isStrongConnection` and `getStronglyConnectedPadIds`
- cover index reuse and multi-pad weighted groups with regression tests

## Root cause

`isStrongConnection` previously scanned the entire `weightedConnections` array twice for every pad-pair check: once to find an explicit pair and again to determine whether either pad rejects weak connections.

Candidate generation and scoring call this function inside nested component/pad loops. On the captured large board, that repeatedly scanned 670 weighted connections across tens of thousands of candidate evaluations.

## Impact

For the same 100,000-step workload in `repro-large-weighted-connections.test.ts`:

- before: about 55.97 seconds
- after: about 3.95 seconds
- improvement: about 14× faster

The indexed run preserves the same solver state at the existing limit: 126 components packed and `failed=true`. Raising the parent iteration budget remains a separate change.

## Validation

- `bun run typecheck`
- `bun test` — 127 pass, 11 pre-existing skips, 0 fail
- focused weighted-connection tests — 7 pass, 0 fail
- large repro benchmark — 100,000 iterations and 126 packed components in about 3.95 seconds
- Biome formatting and `git diff --check`
